### PR TITLE
Eliminate warnings from the test suite

### DIFF
--- a/lib/ex_mcp/server/tools.ex
+++ b/lib/ex_mcp/server/tools.ex
@@ -40,13 +40,15 @@ defmodule ExMCP.Server.Tools do
 
   alias ExMCP.Server.Tools.ResponseNormalizer
 
-  defmacro __using__(_opts) do
-    IO.warn(
-      "ExMCP.Server.Tools is deprecated and will be removed in 1.1.0. " <>
-        "Use ExMCP.Server.Handler with ExMCP.Server.DSL instead " <>
-        "(see ExMCP.Server.DSL and the DSL guide).",
-      Macro.Env.stacktrace(__CALLER__)
-    )
+  defmacro __using__(opts) do
+    if Keyword.get(opts, :warn, true) do
+      IO.warn(
+        "ExMCP.Server.Tools is deprecated and will be removed in 1.1.0. " <>
+          "Use ExMCP.Server.Handler with ExMCP.Server.DSL instead " <>
+          "(see ExMCP.Server.DSL and the DSL guide).",
+        Macro.Env.stacktrace(__CALLER__)
+      )
+    end
 
     quote do
       import ExMCP.Server.Tools

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule ExMCP.MixProject do
       version: @version,
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
+      test_ignore_filters: [~r"^test/conformance/(client|server)\.exs$"],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),

--- a/test/ex_mcp/batch_integration_test.exs
+++ b/test/ex_mcp/batch_integration_test.exs
@@ -9,7 +9,6 @@ defmodule ExMCP.BatchIntegrationTest do
   defmodule TestHandler do
     @behaviour ExMCP.Server.Handler
 
-    @impl true
     def init(_args) do
       {:ok, %{}}
     end
@@ -79,7 +78,6 @@ defmodule ExMCP.BatchIntegrationTest do
       {:ok, %{}, state}
     end
 
-    @impl true
     def terminate(_reason, _state) do
       :ok
     end

--- a/test/ex_mcp/bidirectional_test.exs
+++ b/test/ex_mcp/bidirectional_test.exs
@@ -51,7 +51,6 @@ defmodule ExMCP.BidirectionalTest do
   defmodule TestServerHandler do
     @behaviour ExMCP.Server.Handler
 
-    @impl true
     def init(_args) do
       {:ok, %{}}
     end
@@ -121,7 +120,6 @@ defmodule ExMCP.BidirectionalTest do
       {:ok, %{}, state}
     end
 
-    @impl true
     def terminate(_reason, _state) do
       :ok
     end

--- a/test/ex_mcp/cancellation_comprehensive_test.exs
+++ b/test/ex_mcp/cancellation_comprehensive_test.exs
@@ -17,7 +17,6 @@ defmodule ExMCP.CancellationComprehensiveTest do
   defmodule SlowHandler do
     @behaviour Handler
 
-    @impl true
     def init(_args) do
       # Create ETS table for cancellation tracking if it doesn't exist
       case :ets.info(:cancellation_tracker) do
@@ -206,7 +205,6 @@ defmodule ExMCP.CancellationComprehensiveTest do
     # Note: handle_cancelled is not part of the Handler behaviour
     # Cancellation is handled by the server infrastructure
 
-    @impl true
     def terminate(_reason, _state) do
       :ok
     end

--- a/test/ex_mcp/cancellation_test.exs
+++ b/test/ex_mcp/cancellation_test.exs
@@ -13,7 +13,6 @@ defmodule ExMCP.CancellationTest do
   defmodule TestHandler do
     @behaviour Handler
 
-    @impl true
     def init(_args) do
       {:ok, %{}}
     end
@@ -48,7 +47,6 @@ defmodule ExMCP.CancellationTest do
       {:ok, [%{type: "text", text: "Slow operation completed"}], state}
     end
 
-    @impl true
     def terminate(_reason, _state) do
       :ok
     end

--- a/test/ex_mcp/client/response_test.exs
+++ b/test/ex_mcp/client/response_test.exs
@@ -795,9 +795,9 @@ defmodule ExMCP.Client.ResponseTest do
       # We can't easily test this directly, but we can test edge cases
 
       # The public API should handle edge cases gracefully
-      assert Response.normalize_tool(%{}) != nil
-      assert Response.normalize_resource(%{}) != nil
-      assert Response.normalize_prompt(%{}) != nil
+      assert %{metadata: %{}} = Response.normalize_tool(%{})
+      assert %{metadata: %{}} = Response.normalize_resource(%{})
+      assert %{metadata: %{}} = Response.normalize_prompt(%{})
     end
   end
 

--- a/test/ex_mcp/client_retry_test.exs
+++ b/test/ex_mcp/client_retry_test.exs
@@ -130,30 +130,20 @@ defmodule ExMCP.ClientRetryTest do
       retry_policy = [max_attempts: 3]
 
       # The :use_default symbol should be handled
-      effective_policy =
-        if retry_policy == :use_default do
-          []
-        else
-          case retry_policy do
-            false -> []
-            [] -> []
-            policy when is_list(policy) -> policy
-          end
-        end
+      effective_policy = normalize_retry_policy(retry_policy)
 
       assert effective_policy == [max_attempts: 3]
+      assert normalize_retry_policy(:use_default) == []
 
       # Test disabled retry
       disabled_policy = false
-
-      effective_disabled =
-        case disabled_policy do
-          false -> []
-          [] -> []
-          policy when is_list(policy) -> policy
-        end
+      effective_disabled = normalize_retry_policy(disabled_policy)
 
       assert effective_disabled == []
     end
   end
+
+  defp normalize_retry_policy(:use_default), do: []
+  defp normalize_retry_policy(false), do: []
+  defp normalize_retry_policy(policy) when is_list(policy), do: policy
 end

--- a/test/ex_mcp/compliance/elicitation_compliance_test.exs
+++ b/test/ex_mcp/compliance/elicitation_compliance_test.exs
@@ -70,7 +70,6 @@ defmodule ExMCP.Compliance.ElicitationComplianceTest do
   defmodule TestServerHandler do
     @behaviour ExMCP.Server.Handler
 
-    @impl true
     def init(args), do: {:ok, args}
 
     @impl true

--- a/test/ex_mcp/compliance/structured_output_compliance_test.exs
+++ b/test/ex_mcp/compliance/structured_output_compliance_test.exs
@@ -16,7 +16,7 @@ defmodule ExMCP.Compliance.StructuredOutputComplianceTest do
 
   defmodule TestServer do
     use ExMCP.Server.Handler
-    use ExMCP.Server.Tools
+    use ExMCP.Server.Tools, warn: false
 
     tool "weather_tool" do
       title("Weather Information Tool")

--- a/test/ex_mcp/content/builders_test.exs
+++ b/test/ex_mcp/content/builders_test.exs
@@ -427,14 +427,18 @@ defmodule ExMCP.Content.BuildersTest do
 
     test "resize returns error placeholder" do
       image_content = Builders.image("data", "image/png")
-      result = Builders.resize(image_content, 100, 100)
+      # Invoke dynamically so this compatibility test does not emit a deprecation warning.
+      # credo:disable-for-next-line Credo.Check.Refactor.Apply
+      result = apply(Builders, :resize, [image_content, 100, 100])
 
       assert {:error, _} = result
     end
 
     test "compress returns error placeholder" do
       image_content = Builders.image("data", "image/png")
-      result = Builders.compress(image_content)
+      # Invoke dynamically so this compatibility test does not emit a deprecation warning.
+      # credo:disable-for-next-line Credo.Check.Refactor.Apply
+      result = apply(Builders, :compress, [image_content])
 
       assert {:error, _} = result
     end

--- a/test/ex_mcp/helpers_test.exs
+++ b/test/ex_mcp/helpers_test.exs
@@ -106,7 +106,9 @@ defmodule ExMCP.HelpersTest do
     test "preserves return value on exception" do
       assert_raise RuntimeError, "test error", fn ->
         measure do
-          raise "test error"
+          # Keep the call dynamic so the compiler can verify the macro's exception path.
+          # credo:disable-for-next-line Credo.Check.Refactor.Apply
+          apply(:erlang, :error, [RuntimeError.exception("test error")])
         end
       end
     end

--- a/test/ex_mcp/integration/agent_simulation_test.exs
+++ b/test/ex_mcp/integration/agent_simulation_test.exs
@@ -77,9 +77,6 @@ defmodule ExMCP.Integration.AgentSimulationTest do
 
       {:text_response, text} ->
         {:ok, conversation ++ [%{role: "assistant", content: text}]}
-
-      {:error, reason} ->
-        {:error, reason, conversation}
     end
   end
 

--- a/test/ex_mcp/integration/concurrent_clients_test.exs
+++ b/test/ex_mcp/integration/concurrent_clients_test.exs
@@ -17,20 +17,13 @@ defmodule ExMCP.Integration.ConcurrentClientsTest.TestConcurrentHandler do
 
   @impl GenServer
   def handle_call({:initialize, params}, _from, state) do
-    case handle_initialize(params, state) do
-      {:ok, result, new_state} -> {:reply, {:ok, result, new_state}, new_state}
-      {:error, reason, new_state} -> {:reply, {:error, reason, new_state}, new_state}
-    end
+    {:ok, result, new_state} = handle_initialize(params, state)
+    {:reply, {:ok, result, new_state}, new_state}
   end
 
   def handle_call({:list_tools, cursor}, _from, state) do
-    case handle_list_tools(cursor, state) do
-      {:ok, tools, next_cursor, new_state} ->
-        {:reply, {:ok, %{"tools" => tools, "nextCursor" => next_cursor}, new_state}, new_state}
-
-      {:error, reason, new_state} ->
-        {:reply, {:error, reason, new_state}, new_state}
-    end
+    {:ok, tools, next_cursor, new_state} = handle_list_tools(cursor, state)
+    {:reply, {:ok, %{"tools" => tools, "nextCursor" => next_cursor}, new_state}, new_state}
   end
 
   def handle_call({:call_tool, name, args}, _from, state) do
@@ -140,20 +133,13 @@ defmodule ExMCP.Integration.ConcurrentClientsTest.ErrorProneHandler do
 
   @impl GenServer
   def handle_call({:initialize, params}, _from, state) do
-    case handle_initialize(params, state) do
-      {:ok, result, new_state} -> {:reply, {:ok, result, new_state}, new_state}
-      {:error, reason, new_state} -> {:reply, {:error, reason, new_state}, new_state}
-    end
+    {:ok, result, new_state} = handle_initialize(params, state)
+    {:reply, {:ok, result, new_state}, new_state}
   end
 
   def handle_call({:list_tools, cursor}, _from, state) do
-    case handle_list_tools(cursor, state) do
-      {:ok, tools, next_cursor, new_state} ->
-        {:reply, {:ok, %{"tools" => tools, "nextCursor" => next_cursor}, new_state}, new_state}
-
-      {:error, reason, new_state} ->
-        {:reply, {:error, reason, new_state}, new_state}
-    end
+    {:ok, tools, next_cursor, new_state} = handle_list_tools(cursor, state)
+    {:reply, {:ok, %{"tools" => tools, "nextCursor" => next_cursor}, new_state}, new_state}
   end
 
   def handle_call({:call_tool, name, args}, _from, state) do

--- a/test/ex_mcp/integration/full_workflow_test.exs
+++ b/test/ex_mcp/integration/full_workflow_test.exs
@@ -259,9 +259,9 @@ defmodule ExMCP.Integration.FullWorkflowTest do
           })
 
         # Verify all operations succeeded
-        assert fetch_result != nil
-        assert process_result != nil
-        assert final_result != nil
+        assert fetch_result["tool"] == "data_fetcher"
+        assert process_result["tool"] == "data_processor"
+        assert final_result["tool"] == "result_formatter"
       end)
     end
 
@@ -289,8 +289,8 @@ defmodule ExMCP.Integration.FullWorkflowTest do
             "config" => "simulated_config_from_resource"
           })
 
-        assert config_result != nil
-        assert tool_result != nil
+        assert config_result["uri"] == "file://config.json"
+        assert tool_result["tool"] == "configured_processor"
       end)
     end
 
@@ -318,8 +318,8 @@ defmodule ExMCP.Integration.FullWorkflowTest do
             "prompt" => "simulated_generated_prompt"
           })
 
-        assert prompt_result != nil
-        assert execution_result != nil
+        assert prompt_result["prompt"] == "dynamic_analysis"
+        assert execution_result["tool"] == "executor"
       end)
     end
   end

--- a/test/ex_mcp/performance/schema_compilation_performance_test.exs
+++ b/test/ex_mcp/performance/schema_compilation_performance_test.exs
@@ -123,7 +123,7 @@ defmodule ExMCP.Performance.SchemaCompilationPerformanceTest do
   describe "integration with tools DSL" do
     defmodule TestPerformanceServer do
       use ExMCP.Server.Handler
-      use ExMCP.Server.Tools
+      use ExMCP.Server.Tools, warn: false
 
       tool "perf_test" do
         description("Performance test tool")

--- a/test/ex_mcp/ping_test.exs
+++ b/test/ex_mcp/ping_test.exs
@@ -10,7 +10,6 @@ defmodule ExMCP.PingTest do
   defmodule TestServerHandler do
     @behaviour Handler
 
-    @impl true
     def init(_args) do
       {:ok, %{ping_count: 0}}
     end
@@ -35,7 +34,6 @@ defmodule ExMCP.PingTest do
       {:ok, [%{type: "text", text: "Not implemented"}], state}
     end
 
-    @impl true
     def terminate(_reason, _state) do
       :ok
     end

--- a/test/ex_mcp/server/structured_output_test.exs
+++ b/test/ex_mcp/server/structured_output_test.exs
@@ -8,7 +8,7 @@ defmodule ExMCP.Server.StructuredOutputTest do
 
   defmodule TestServer do
     use ExMCP.Server.Handler
-    use ExMCP.Server.Tools
+    use ExMCP.Server.Tools, warn: false
 
     tool "calculate" do
       description("Perform mathematical calculations with structured output")

--- a/test/ex_mcp/server/tools_test.exs
+++ b/test/ex_mcp/server/tools_test.exs
@@ -5,7 +5,7 @@ defmodule ExMCP.Server.ToolsTest do
     test "defines simple tool with automatic schema generation" do
       defmodule SimpleToolServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         tool "echo", "Echo back the input" do
           param(:message, :string, required: true)
@@ -47,7 +47,7 @@ defmodule ExMCP.Server.ToolsTest do
     test "defines tool with multiple parameters and types" do
       defmodule MultiParamServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         tool "user_info", "Get user information" do
           param(:name, :string, required: true)
@@ -81,7 +81,7 @@ defmodule ExMCP.Server.ToolsTest do
     test "defines advanced tool with full control" do
       defmodule AdvancedToolServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         tool "calculate" do
           description("Perform mathematical calculations")
@@ -146,7 +146,7 @@ defmodule ExMCP.Server.ToolsTest do
     test "supports all annotation types" do
       defmodule AnnotatedToolServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         tool "delete_file" do
           description("Delete a file from the system")
@@ -178,7 +178,7 @@ defmodule ExMCP.Server.ToolsTest do
     test "handles tool execution errors gracefully" do
       defmodule ErrorToolServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         tool "failing_tool", "A tool that fails" do
           param(:trigger_error, :boolean, default: false)
@@ -218,7 +218,7 @@ defmodule ExMCP.Server.ToolsTest do
     test "allows mixing DSL tools with traditional handler methods" do
       defmodule MixedServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         # DSL tool
         tool "simple", "Simple tool" do
@@ -259,7 +259,7 @@ defmodule ExMCP.Server.ToolsTest do
       # This should compile successfully
       defmodule ValidToolServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         tool "valid", "Valid tool" do
           param(:string_param, :string)
@@ -279,7 +279,7 @@ defmodule ExMCP.Server.ToolsTest do
     test "generates correct schema for nested types" do
       defmodule NestedTypeServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         tool "nested", "Tool with nested types" do
           param(:users, {:array, :object},
@@ -322,7 +322,7 @@ defmodule ExMCP.Server.ToolsTest do
     test "supports custom validation in handle function" do
       defmodule ValidationServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         tool "divide", "Divide two numbers" do
           param(:dividend, :number, required: true)
@@ -364,7 +364,7 @@ defmodule ExMCP.Server.ToolsTest do
     test "handles missing required parameters" do
       defmodule RequiredParamServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         tool "greet", "Greet a user" do
           param(:name, :string, required: true)
@@ -416,7 +416,7 @@ defmodule ExMCP.Server.ToolsTest do
     test "supports tool composition" do
       defmodule CompositeServer do
         use ExMCP.Server.Handler
-        use ExMCP.Server.Tools
+        use ExMCP.Server.Tools, warn: false
 
         tool "fetch_data", "Fetch data from source" do
           param(:source, :string)

--- a/test/ex_mcp/structured_output_test.exs
+++ b/test/ex_mcp/structured_output_test.exs
@@ -10,7 +10,6 @@ defmodule ExMCP.StructuredOutputTest do
   defmodule TestHandler do
     @behaviour ExMCP.Server.Handler
 
-    @impl true
     def init(_args), do: {:ok, %{}}
 
     @impl true


### PR DESCRIPTION
## What changed

- fixes compiler warnings in tests by removing invalid `@impl` annotations and unreachable branches
- replaces assertions that are statically always true with meaningful shape/value assertions
- keeps deprecated API coverage without emitting deprecation warnings
- excludes conformance entrypoint scripts from ExUnit test-file discovery
- adds an explicit opt-out for the deprecated `ExMCP.Server.Tools` warning in compatibility tests

## Why

The suite emitted warnings under current Elixir/OTP, so `MIX_ENV=test mix do compile --warnings-as-errors + test --warnings-as-errors` could not be used as a reliable quality gate.

## Impact

There is no runtime protocol behavior change. Tests now compile cleanly when warnings are promoted to errors, while deprecated public APIs continue warning by default.

## Validation

- `MIX_ENV=test mix do clean + compile --warnings-as-errors + test --warnings-as-errors`
- 15 doctests, 34 properties, 2,998 tests, 0 failures (196 excluded)
- repository pre-commit hooks: format, compile with warnings as errors, Credo, Dialyzer, and skip-tag check