### PR TITLE
Normalize protocol field names on the wire

### DIFF
--- a/lib/ex_mcp/message_processor/method_handlers.ex
+++ b/lib/ex_mcp/message_processor/method_handlers.ex
@@ -281,10 +281,17 @@ defmodule ExMCP.MessageProcessor.MethodHandlers do
 
   defp deep_stringify_keys(map) when is_map(map) and not is_struct(map) do
     Map.new(map, fn
-      {key, value} when is_atom(key) -> {Atom.to_string(key), deep_stringify_keys(value)}
+      {key, value} when is_atom(key) -> {protocol_key(key), deep_stringify_keys(value)}
       {key, value} -> {key, deep_stringify_keys(value)}
     end)
   end
 
   defp deep_stringify_keys(value), do: value
+
+  defp protocol_key(:input_schema), do: "inputSchema"
+  defp protocol_key(:output_schema), do: "outputSchema"
+  defp protocol_key(:mime_type), do: "mimeType"
+  defp protocol_key(:uri_template), do: "uriTemplate"
+  defp protocol_key(:list_pattern), do: "listPattern"
+  defp protocol_key(key), do: Atom.to_string(key)
 end

--- a/test/ex_mcp/message_processor_validation_test.exs
+++ b/test/ex_mcp/message_processor_validation_test.exs
@@ -32,7 +32,12 @@ defmodule ExMCP.MessageProcessorValidationTest do
     @impl true
     def handle_list_tools(_cursor, state) do
       tools = [
-        %{name: "test_tool", description: "A test tool", inputSchema: %{}}
+        %{
+          name: "test_tool",
+          description: "A test tool",
+          input_schema: %{},
+          output_schema: %{type: "object"}
+        }
       ]
 
       {:ok, tools, nil, state}
@@ -117,6 +122,10 @@ defmodule ExMCP.MessageProcessorValidationTest do
       # Check the actual structure returned
       tool = hd(tools)
       assert tool["name"] == "test_tool"
+      assert tool["inputSchema"] == %{}
+      assert tool["outputSchema"] == %{"type" => "object"}
+      refute Map.has_key?(tool, "input_schema")
+      refute Map.has_key?(tool, "output_schema")
 
       # Cleanup
       GenServer.stop(server)


### PR DESCRIPTION
## What changed

- converts handler-native snake_case MCP fields to their required camelCase wire names
- covers `inputSchema`, `outputSchema`, `mimeType`, `uriTemplate`, and `listPattern`
- adds a regression test proving snake_case keys do not leak into JSON-RPC responses

## Why

The generic atom-to-string conversion emitted fields such as `input_schema`, which are not valid MCP wire keys. Handler implementations using idiomatic Elixir maps could therefore produce malformed protocol responses.

## Impact

Handler callbacks can keep idiomatic snake_case atoms while clients receive MCP-compliant camelCase JSON keys. All unrelated atom keys retain the existing conversion behavior.

## Validation

- `mix format --check-formatted`
- `MIX_ENV=test mix test test/ex_mcp/message_processor_validation_test.exs --warnings-as-errors`
- 8 targeted tests passed
- repository compile-with-warnings-as-errors and Credo hook stages passed under Elixir 1.19.5; the combined hook was interrupted after repeated build-lock contention with another checkout