### PR TITLE
Add multi-client resource subscriptions

### DIFF
--- a/lib/ex_mcp/application.ex
+++ b/lib/ex_mcp/application.ex
@@ -12,19 +12,20 @@ defmodule ExMCP.Application do
       configure_stdio_logging()
     end
 
-    children =
-      [
-        # Dynamic supervisor for runtime components
-        {DynamicSupervisor, strategy: :one_for_one, name: ExMCP.DynamicSupervisor},
-        # Start the Consent Cache for security features
-        ExMCP.Internal.ConsentCache,
-        # Start the Session Manager for streamable HTTP sessions
-        ExMCP.SessionManager,
-        # Start the Progress Tracker for 2025-06-18 progress notifications
-        ExMCP.ProgressTracker,
-        # Start the Reliability Supervisor for circuit breakers and health checks
-        {ExMCP.Reliability.Supervisor, name: ExMCP.Reliability.Supervisor}
-      ]
+    children = [
+      # Dynamic supervisor for runtime components
+      {DynamicSupervisor, strategy: :one_for_one, name: ExMCP.DynamicSupervisor},
+      # Start the Consent Cache for security features
+      ExMCP.Internal.ConsentCache,
+      # Start the Session Manager for streamable HTTP sessions
+      ExMCP.SessionManager,
+      # Track resource subscriptions independently for every client session
+      ExMCP.SubscriptionRegistry,
+      # Start the Progress Tracker for 2025-06-18 progress notifications
+      ExMCP.ProgressTracker,
+      # Start the Reliability Supervisor for circuit breakers and health checks
+      {ExMCP.Reliability.Supervisor, name: ExMCP.Reliability.Supervisor}
+    ]
 
     opts = [strategy: :one_for_one, name: ExMCP.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/ex_mcp/http_plug.ex
+++ b/lib/ex_mcp/http_plug.ex
@@ -243,13 +243,19 @@ defmodule ExMCP.HttpPlug do
     # The server provides session IDs to clients via response headers.
     session_id = get_or_create_session_id(conn)
 
+    session_manager =
+      opts
+      |> Map.get(:session_manager, ExMCP.SessionManager)
+      |> ensure_session_manager()
+
     with {:ok, conn} <- validate_request_origin(conn, opts),
          {:ok, conn} <- validate_protocol_version(conn),
          {:ok, body, conn} <- read_or_cached_body(conn, opts),
          {:ok, request} <- parse_json(body),
          {:ok, _token_info} <- authorize_request(conn, request, opts),
          {:ok, opts} <- resolve_handler_opts(conn, request, opts),
-         result <- process_mcp_request(request, opts) do
+         :ok <- maybe_ensure_session(session_manager, session_id, %{transport: :http}),
+         result <- process_mcp_request(request, Map.put(opts, :session_id, session_id)) do
       Logger.debug("MCP request processed, result: #{inspect(result)}")
 
       case result do
@@ -468,6 +474,7 @@ defmodule ExMCP.HttpPlug do
 
       # Terminate the session
       :ok = session_manager.terminate_session(session_id)
+      :ok = remove_session_subscriptions(session_id)
 
       # Try to stop the SSE handler if it exists
       case lookup_sse_handler(session_id) do
@@ -588,6 +595,7 @@ defmodule ExMCP.HttpPlug do
           {:DOWN, ^ref, :process, ^handler, reason} ->
             # Clean up the session registry when handler exits
             cleanup_sse_handler(final_session_id)
+            remove_session_subscriptions(final_session_id)
 
             # Terminate session in SessionManager if it was a clean shutdown
             if reason == :normal do
@@ -626,6 +634,21 @@ defmodule ExMCP.HttpPlug do
 
   defp ensure_session_manager(session_manager), do: session_manager
 
+  defp maybe_ensure_session(session_manager, session_id, metadata) do
+    if function_exported?(session_manager, :ensure_session, 2) do
+      session_manager.ensure_session(session_id, metadata)
+    else
+      :ok
+    end
+  end
+
+  defp remove_session_subscriptions(session_id) do
+    case Process.whereis(ExMCP.SubscriptionRegistry) do
+      nil -> :ok
+      _pid -> ExMCP.SubscriptionRegistry.remove_session(session_id)
+    end
+  end
+
   # Process MCP request using the configured handler
   defp process_mcp_request(request, opts) do
     handler = opts.handler
@@ -638,7 +661,11 @@ defmodule ExMCP.HttpPlug do
 
       handler_module when is_atom(handler_module) ->
         # Use ExMCP.MessageProcessor to process the request
-        conn = ExMCP.MessageProcessor.new(request, transport: :http)
+        conn =
+          ExMCP.MessageProcessor.new(request,
+            transport: :http,
+            session_id: Map.get(opts, :session_id)
+          )
 
         # Create a simple processor that delegates to the handler
         processed_conn =
@@ -783,6 +810,42 @@ defmodule ExMCP.HttpPlug do
     end
   rescue
     ArgumentError -> {:error, :table_not_found}
+  end
+
+  @doc """
+  Broadcasts a resource-updated notification to every live SSE client that
+  subscribed to `uri`. Slow clients receive independent backpressure and do
+  not block delivery to other sessions.
+  """
+  def broadcast_resource_update(uri) when is_binary(uri) do
+    notification = %{
+      "jsonrpc" => "2.0",
+      "method" => "notifications/resources/updated",
+      "params" => %{"uri" => uri}
+    }
+
+    results =
+      uri
+      |> ExMCP.SubscriptionRegistry.sessions()
+      |> Task.async_stream(
+        fn session_id ->
+          with {:ok, handler} <- lookup_sse_handler(session_id),
+               true <- Process.alive?(handler),
+               :ok <- SSEHandler.request_send(handler) do
+            SSEHandler.send_event(handler, "message", notification)
+            {:ok, session_id}
+          else
+            _ -> {:stale, session_id}
+          end
+        end,
+        ordered: false,
+        timeout: 5_000,
+        on_timeout: :kill_task
+      )
+      |> Enum.to_list()
+
+    delivered = Enum.count(results, &match?({:ok, {:ok, _}}, &1))
+    %{subscribers: length(results), delivered: delivered}
   end
 
   # Clean up SSE handler registration

--- a/lib/ex_mcp/message_processor.ex
+++ b/lib/ex_mcp/message_processor.ex
@@ -180,15 +180,14 @@ defmodule ExMCP.MessageProcessor do
 
   # Process request using Handler Server with GenServer
   defp process_with_handler_genserver(conn, handler_module, server_info, handler_opts) do
-    # Start the handler as a GenServer
-    case GenServer.start_link(handler_module, handler_opts) do
-      {:ok, server_pid} ->
+    case start_handler_server(handler_module, handler_opts) do
+      {:ok, server_pid, owned?} ->
         try do
           # Process the request using the handler's GenServer interface
           process_handler_request(conn, server_pid, server_info)
         after
           # Clean up the temporary server
-          if Process.alive?(server_pid) do
+          if owned? and Process.alive?(server_pid) do
             GenServer.stop(server_pid, :normal, 1000)
           end
         end
@@ -203,6 +202,20 @@ defmodule ExMCP.MessageProcessor do
           )
 
         put_response(conn, error_response)
+    end
+  end
+
+  defp start_handler_server(handler_module, handler_opts) do
+    case Process.whereis(handler_module) do
+      pid when is_pid(pid) ->
+        {:ok, pid, false}
+
+      nil ->
+        case GenServer.start_link(handler_module, handler_opts) do
+          {:ok, pid} -> {:ok, pid, true}
+          {:error, {:already_started, pid}} -> {:ok, pid, false}
+          other -> other
+        end
     end
   end
 

--- a/lib/ex_mcp/message_processor/method_handlers.ex
+++ b/lib/ex_mcp/message_processor/method_handlers.ex
@@ -130,8 +130,8 @@ defmodule ExMCP.MessageProcessor.MethodHandlers do
     uri = Map.get(params, "uri")
 
     case GenServer.call(server_pid, {:subscribe_resource, uri}, 5000) do
-      :ok -> put_success(conn, %{}, id)
-      {:ok, _state} -> put_success(conn, %{}, id)
+      :ok -> register_subscription(conn, uri, id)
+      {:ok, _state} -> register_subscription(conn, uri, id)
       {:error, reason} -> put_error(conn, "Subscribe failed", reason, id)
     end
   rescue
@@ -142,13 +142,33 @@ defmodule ExMCP.MessageProcessor.MethodHandlers do
     uri = Map.get(params, "uri")
 
     case GenServer.call(server_pid, {:unsubscribe_resource, uri}, 5000) do
-      :ok -> put_success(conn, %{}, id)
-      {:ok, _state} -> put_success(conn, %{}, id)
+      :ok -> unregister_subscription(conn, uri, id)
+      {:ok, _state} -> unregister_subscription(conn, uri, id)
       {:error, reason} -> put_error(conn, "Unsubscribe failed", reason, id)
     end
   rescue
     error -> put_error(conn, "Unsubscribe failed", error, id)
   end
+
+  defp register_subscription(%{session_id: session_id} = conn, uri, id)
+       when is_binary(session_id) do
+    case ExMCP.SubscriptionRegistry.subscribe(session_id, uri) do
+      :ok -> put_success(conn, %{}, id)
+      {:error, reason} -> put_error(conn, "Subscribe failed", reason, id)
+    end
+  end
+
+  defp register_subscription(conn, _uri, id), do: put_success(conn, %{}, id)
+
+  defp unregister_subscription(%{session_id: session_id} = conn, uri, id)
+       when is_binary(session_id) do
+    case ExMCP.SubscriptionRegistry.unsubscribe(session_id, uri) do
+      :ok -> put_success(conn, %{}, id)
+      {:error, reason} -> put_error(conn, "Unsubscribe failed", reason, id)
+    end
+  end
+
+  defp unregister_subscription(conn, _uri, id), do: put_success(conn, %{}, id)
 
   def handle_prompts_list(conn, server_pid, params, id) do
     cursor = Map.get(params, "cursor")

--- a/lib/ex_mcp/session_manager.ex
+++ b/lib/ex_mcp/session_manager.ex
@@ -123,6 +123,18 @@ defmodule ExMCP.SessionManager do
   end
 
   @doc """
+  Ensures a transport-issued session ID exists and remains active.
+
+  Streamable HTTP creates the ID on the first POST, before the SSE connection
+  is opened. Registering that exact ID keeps subscriptions and event delivery
+  attached to one client identity across both channels.
+  """
+  @spec ensure_session(session_id(), map()) :: :ok
+  def ensure_session(session_id, metadata \\ %{}) when is_binary(session_id) do
+    GenServer.call(__MODULE__, {:ensure_session, session_id, metadata})
+  end
+
+  @doc """
   Stores an event for the given session.
 
   Events are stored with their ID, type, data, and timestamp for potential
@@ -273,6 +285,33 @@ defmodule ExMCP.SessionManager do
 
     Logger.debug("Created session #{session_id} with transport #{session_data.transport}")
     {:reply, session_id, state}
+  end
+
+  def handle_call({:ensure_session, session_id, metadata}, _from, state) do
+    now = System.system_time(:microsecond)
+
+    session_data =
+      case :ets.lookup(state.sessions_table, session_id) do
+        [{^session_id, session}] ->
+          session
+          |> Map.merge(metadata)
+          |> Map.put(:status, :active)
+          |> Map.put(:last_activity, now)
+
+        [] ->
+          %{
+            id: session_id,
+            transport: Map.get(metadata, :transport, :http),
+            client_info: Map.get(metadata, :client_info, %{}),
+            created_at: now,
+            last_activity: now,
+            event_count: 0,
+            status: :active
+          }
+      end
+
+    :ets.insert(state.sessions_table, {session_id, session_data})
+    {:reply, :ok, state}
   end
 
   @impl true

--- a/lib/ex_mcp/subscription_registry.ex
+++ b/lib/ex_mcp/subscription_registry.ex
@@ -1,0 +1,85 @@
+defmodule ExMCP.SubscriptionRegistry do
+  @moduledoc """
+  Tracks MCP resource subscriptions independently for every client session.
+
+  A server process is shared, while subscriptions belong to the HTTP/SSE
+  session that requested them. This registry is deliberately transport-neutral;
+  transports resolve session IDs to their live delivery processes.
+  """
+
+  use GenServer
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  def subscribe(session_id, uri) when is_binary(session_id) and is_binary(uri),
+    do: GenServer.call(__MODULE__, {:subscribe, session_id, uri})
+
+  def subscribe(_, _), do: {:error, :session_and_uri_required}
+
+  def unsubscribe(session_id, uri) when is_binary(session_id) and is_binary(uri),
+    do: GenServer.call(__MODULE__, {:unsubscribe, session_id, uri})
+
+  def unsubscribe(_, _), do: {:error, :session_and_uri_required}
+
+  def remove_session(session_id) when is_binary(session_id),
+    do: GenServer.call(__MODULE__, {:remove_session, session_id})
+
+  def sessions(uri) when is_binary(uri), do: GenServer.call(__MODULE__, {:sessions, uri})
+  def subscriptions(session_id), do: GenServer.call(__MODULE__, {:subscriptions, session_id})
+
+  @impl true
+  def init(_opts), do: {:ok, %{by_uri: %{}, by_session: %{}}}
+
+  @impl true
+  def handle_call({:subscribe, session_id, uri}, _from, state) do
+    by_uri = Map.update(state.by_uri, uri, MapSet.new([session_id]), &MapSet.put(&1, session_id))
+
+    by_session =
+      Map.update(state.by_session, session_id, MapSet.new([uri]), &MapSet.put(&1, uri))
+
+    {:reply, :ok, %{state | by_uri: by_uri, by_session: by_session}}
+  end
+
+  def handle_call({:unsubscribe, session_id, uri}, _from, state) do
+    {:reply, :ok, drop_subscription(state, session_id, uri)}
+  end
+
+  def handle_call({:remove_session, session_id}, _from, state) do
+    state =
+      state.by_session
+      |> Map.get(session_id, MapSet.new())
+      |> Enum.reduce(state, &drop_subscription(&2, session_id, &1))
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:sessions, uri}, _from, state) do
+    {:reply, state.by_uri |> Map.get(uri, MapSet.new()) |> Enum.sort(), state}
+  end
+
+  def handle_call({:subscriptions, session_id}, _from, state) do
+    {:reply, state.by_session |> Map.get(session_id, MapSet.new()) |> Enum.sort(), state}
+  end
+
+  defp drop_subscription(state, session_id, uri) do
+    by_uri = drop_member(state.by_uri, uri, session_id)
+    by_session = drop_member(state.by_session, session_id, uri)
+    %{state | by_uri: by_uri, by_session: by_session}
+  end
+
+  defp drop_member(index, key, member) do
+    case Map.get(index, key) do
+      nil ->
+        index
+
+      members ->
+        remaining = MapSet.delete(members, member)
+
+        if MapSet.size(remaining) == 0,
+          do: Map.delete(index, key),
+          else: Map.put(index, key, remaining)
+    end
+  end
+end

--- a/test/ex_mcp/http_plug_test.exs
+++ b/test/ex_mcp/http_plug_test.exs
@@ -58,6 +58,10 @@ defmodule ExMCP.HttpPlugTest do
 
     def create_session(_attrs), do: "tracked_session"
 
+    def ensure_session(session_id, metadata) do
+      notify({:session_ensured, session_id, metadata})
+    end
+
     def update_session(session_id, attrs) do
       notify({:session_updated, session_id, attrs})
     end
@@ -140,6 +144,8 @@ defmodule ExMCP.HttpPlugTest do
     end
 
     test "rejects browser origins unless explicitly allowed or same-origin" do
+      {:ok, _} = TrackingSessionManager.start_link(self())
+
       request = %{
         "jsonrpc" => "2.0",
         "method" => "initialize",
@@ -150,10 +156,17 @@ defmodule ExMCP.HttpPlugTest do
         conn(:post, "/", Jason.encode!(request))
         |> put_req_header("content-type", "application/json")
         |> put_req_header("origin", "https://evil.example")
-        |> HttpPlug.call(HttpPlug.init(handler: TestServer, sse_enabled: false))
+        |> HttpPlug.call(
+          HttpPlug.init(
+            handler: TestServer,
+            sse_enabled: false,
+            session_manager: TrackingSessionManager
+          )
+        )
 
       assert conn.status == 403
       assert conn.resp_body == "Origin not allowed"
+      refute_received {:session_ensured, _, _}
     end
 
     test "allows explicitly configured browser origins" do

--- a/test/ex_mcp/subscription_registry_test.exs
+++ b/test/ex_mcp/subscription_registry_test.exs
@@ -1,0 +1,45 @@
+defmodule ExMCP.SubscriptionRegistryTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    ensure_started(ExMCP.SessionManager)
+    ensure_started(ExMCP.SubscriptionRegistry)
+    :ok
+  end
+
+  test "many client sessions subscribe independently to one resource" do
+    uri = "test://shared"
+    sessions = [unique_session("a"), unique_session("b")]
+
+    Enum.each(sessions, fn session_id ->
+      assert :ok = ExMCP.SubscriptionRegistry.subscribe(session_id, uri)
+    end)
+
+    assert ExMCP.SubscriptionRegistry.sessions(uri) == Enum.sort(sessions)
+    assert :ok = ExMCP.SubscriptionRegistry.unsubscribe(hd(sessions), uri)
+    assert ExMCP.SubscriptionRegistry.sessions(uri) == [List.last(sessions)]
+  end
+
+  test "transport-issued HTTP session identity is retained for SSE" do
+    session_id = unique_session("http")
+
+    assert :ok = ExMCP.SessionManager.ensure_session(session_id, %{transport: :http})
+    assert {:ok, session} = ExMCP.SessionManager.get_session(session_id)
+    assert session.id == session_id
+    assert session.transport == :http
+
+    assert :ok = ExMCP.SessionManager.ensure_session(session_id, %{transport: :sse})
+    assert {:ok, resumed} = ExMCP.SessionManager.get_session(session_id)
+    assert resumed.id == session_id
+    assert resumed.transport == :sse
+  end
+
+  defp unique_session(prefix),
+    do: "#{prefix}-#{System.unique_integer([:positive, :monotonic])}"
+
+  defp ensure_started(module) do
+    if Process.whereis(module) == nil do
+      start_supervised!(module)
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- preserves one HTTP-issued session identity across POST and SSE channels
- tracks resource subscriptions independently per client session
- cleans subscription state up when sessions terminate or SSE handlers exit
- broadcasts `notifications/resources/updated` to all subscribed live SSE clients with per-client backpressure
- reuses an already-running module-named handler instead of stopping shared server state after each request
- ensures rejected origin/auth requests do not allocate session state

## Why

Resource subscriptions were delegated to the server handler but were not associated with the requesting HTTP/SSE session. A shared server therefore could not route resource-update notifications to multiple subscribed clients reliably, and temporary handler startup discarded state between requests.

## Impact

Multiple streamable-HTTP clients can subscribe to the same resource independently and receive server-initiated update notifications without blocking each other. Existing handlers without an HTTP session ID retain their previous subscribe/unsubscribe behavior.

## Validation

- `MIX_ENV=test mix test test/ex_mcp/subscription_registry_test.exs test/ex_mcp/http_plug_test.exs test/ex_mcp/message_processor_validation_test.exs --warnings-as-errors` — 33 tests, 0 failures
- complete suite — 15 doctests, 34 properties, 3,000 tests, 0 failures (196 excluded)
- repository pre-commit hooks — format, compile with warnings as errors, Credo, Dialyzer, and skip-tag check