### PR TITLE
Make per-request handler teardown best-effort (stop timeout no longer 500s a built response)

### DIFF
--- a/lib/ex_mcp/message_processor.ex
+++ b/lib/ex_mcp/message_processor.ex
@@ -188,9 +188,7 @@ defmodule ExMCP.MessageProcessor do
           process_handler_request(conn, server_pid, server_info)
         after
           # Clean up the temporary server
-          if Process.alive?(server_pid) do
-            GenServer.stop(server_pid, :normal, 1000)
-          end
+          stop_temporary_server(server_pid)
         end
 
       {:error, reason} ->
@@ -210,6 +208,35 @@ defmodule ExMCP.MessageProcessor do
   defp process_handler_request(conn, server_pid, server_info) do
     conn = assign(conn, :server_info, server_info)
     dispatch_to_method_handlers(conn, server_pid)
+  end
+
+  # Best-effort teardown of a per-request handler GenServer.
+  #
+  # By the time this runs (inside the enclosing `try/after`) the JSON response
+  # for the request is ALREADY built and is the value the `try` returns — this
+  # is pure cleanup. A handler that is slow to terminate (e.g. it just did a
+  # heavy tool call) must therefore never turn a successful tool result into a
+  # transport error.
+  #
+  # `GenServer.stop/3` exits the CALLING process with `:timeout` if the handler
+  # doesn't terminate within the budget; letting that escape the `after` discards
+  # the built response and 500s the request (the client then sees a non-JSON
+  # error page). So: give terminate real headroom, swallow a stop timeout, and
+  # hard-kill as the backstop. The handler was `start_link`'d to us, so unlink
+  # before `:kill` — otherwise the signal propagates back through the link and
+  # crashes the very request we are trying to answer.
+  defp stop_temporary_server(server_pid) do
+    if Process.alive?(server_pid) do
+      try do
+        GenServer.stop(server_pid, :normal, 5_000)
+      catch
+        :exit, _ ->
+          Process.unlink(server_pid)
+          Process.exit(server_pid, :kill)
+      end
+    end
+
+    :ok
   end
 
   alias ExMCP.MessageProcessor.MethodHandlers


### PR DESCRIPTION
## Problem

`MessageProcessor.process_with_handler_genserver/4` starts a per-request handler with `GenServer.start_link` (so it is **linked** to the request process), builds the JSON response inside a `try`, then cleans up in the `after`:

```elixir
after
  if Process.alive?(server_pid) do
    GenServer.stop(server_pid, :normal, 1000)
  end
end
```

`GenServer.stop/3` does not return an error on timeout — it **exits the calling process** with `:timeout`. If the handler is slow to terminate (e.g. it just finished a heavy `tools/call` doing an export + disk write), the exit escapes the `after`, discards the already-built response, and the request 500s. The client receives a non-JSON error page ("Transport send error / Unexpected content type: text/html…") for a tool call that actually **succeeded** — and typically retries it, re-running a non-idempotent operation.

We hit this intermittently in production with document-save tools: the save completed, the response was built, and teardown timing turned it into a transport error + retry loop.

## Fix

Extract teardown into `stop_temporary_server/1`, which treats cleanup as best-effort — by the time it runs the response is already the `try`'s return value, so cleanup must never be able to fail the request:

- give `terminate/2` real headroom (5s instead of 1s),
- catch the stop-timeout exit instead of letting it escape the `after`,
- hard-kill as the backstop, **unlinking first** — the handler is linked to the request process, so killing while linked would propagate the exit signal back through the link and crash the very request being answered.

## Verification

- `mix compile --warnings-as-errors` clean
- `mix test test/ex_mcp/message_processor_test.exs test/ex_mcp/message_processor_validation_test.exs` — 17 passed
- `mix credo lib/ex_mcp/message_processor.ex` — only the pre-existing missing-`@moduledoc` note (full `mix credo` currently crashes locally under Elixir 1.20 due to a Credo 1.7.12 sigil-tokenizer incompatibility, unrelated to this change)
- Running this patch (against the 0.10.0-era code, which had the same teardown in two places) in our app for the past month: the transport-error-on-successful-save failure mode has not recurred

🤖 Generated with [Claude Code](https://claude.com/claude-code)