### PR TITLE
Handle structured Codex approval decisions

### DIFF
--- a/lib/ex_mcp/acp/adapters/codex.ex
+++ b/lib/ex_mcp/acp/adapters/codex.ex
@@ -2918,8 +2918,6 @@ defmodule ExMCP.ACP.Adapters.Codex do
     end
   end
 
-  defp decode_structured_decision(_option_id), do: :error
-
   defp structured_decision_name(decision) do
     case Map.keys(decision) do
       [name] when is_binary(name) -> name |> Macro.underscore() |> humanize_option()

--- a/lib/ex_mcp/acp/adapters/codex.ex
+++ b/lib/ex_mcp/acp/adapters/codex.ex
@@ -15,6 +15,8 @@ defmodule ExMCP.ACP.Adapters.Codex do
   alias ExMCP.ACP.{AdapterEvents, Envelope, PendingRequests}
   alias ExMCP.Internal.{Maps, NameValue}
 
+  @structured_decision_prefix "codex:decision:"
+
   defstruct [
     :model,
     :mode_id,
@@ -2798,6 +2800,14 @@ defmodule ExMCP.ACP.Adapters.Codex do
     %{"optionId" => id, "name" => name, "kind" => option_kind(id)}
   end
 
+  defp decision_to_option(decision) when is_map(decision) do
+    %{
+      "optionId" => @structured_decision_prefix <> Jason.encode!(decision),
+      "name" => structured_decision_name(decision),
+      "kind" => structured_decision_kind(decision)
+    }
+  end
+
   defp decision_to_option(decision) when is_binary(decision) do
     %{
       "optionId" => decision,
@@ -2812,6 +2822,16 @@ defmodule ExMCP.ACP.Adapters.Codex do
          "result" => %{"outcome" => %{"outcome" => "cancelled"}}
        }) do
     codex_cancel_response(method)
+  end
+
+  defp permission_response(
+         %{
+           method: "item/commandExecution/requestApproval",
+           params: %{"availableDecisions" => available_decisions}
+         },
+         %{"result" => %{"outcome" => %{"optionId" => option_id}}}
+       ) do
+    %{"decision" => command_approval_decision(option_id, available_decisions)}
   end
 
   defp permission_response(%{method: method}, %{
@@ -2860,6 +2880,20 @@ defmodule ExMCP.ACP.Adapters.Codex do
 
   defp codex_cancel_response(_method), do: %{"decision" => "cancel"}
 
+  defp command_approval_decision(option_id, available_decisions) do
+    if structured_decision_option_id?(option_id) do
+      with true <- is_list(available_decisions),
+           {:ok, decision} <- decode_structured_decision(option_id),
+           true <- Enum.member?(available_decisions, decision) do
+        decision
+      else
+        _ -> "decline"
+      end
+    else
+      app_server_decision(option_id)
+    end
+  end
+
   defp app_server_decision(option_id) do
     cond do
       always_option?(option_id) -> "acceptForSession"
@@ -2868,6 +2902,45 @@ defmodule ExMCP.ACP.Adapters.Codex do
       true -> "decline"
     end
   end
+
+  defp structured_decision_option_id?(option_id) when is_binary(option_id),
+    do: String.starts_with?(option_id, @structured_decision_prefix)
+
+  defp structured_decision_option_id?(_option_id), do: false
+
+  defp decode_structured_decision(option_id) when is_binary(option_id) do
+    with true <- String.starts_with?(option_id, @structured_decision_prefix),
+         encoded <- String.replace_prefix(option_id, @structured_decision_prefix, ""),
+         {:ok, decision} when is_map(decision) <- Jason.decode(encoded) do
+      {:ok, decision}
+    else
+      _ -> :error
+    end
+  end
+
+  defp decode_structured_decision(_option_id), do: :error
+
+  defp structured_decision_name(decision) do
+    case Map.keys(decision) do
+      [name] when is_binary(name) -> name |> Macro.underscore() |> humanize_option()
+      _ -> "Codex Decision"
+    end
+  end
+
+  defp structured_decision_kind(%{"acceptWithExecpolicyAmendment" => _amendment}),
+    do: "allow_always"
+
+  defp structured_decision_kind(%{
+         "applyNetworkPolicyAmendment" => %{
+           "network_policy_amendment" => %{"action" => "deny"}
+         }
+       }),
+       do: "reject_always"
+
+  defp structured_decision_kind(%{"applyNetworkPolicyAmendment" => _amendment}),
+    do: "allow_always"
+
+  defp structured_decision_kind(_decision), do: "reject_once"
 
   defp legacy_review_decision(option_id) do
     cond do

--- a/test/ex_mcp/acp/adapters/codex_test.exs
+++ b/test/ex_mcp/acp/adapters/codex_test.exs
@@ -721,6 +721,143 @@ defmodule ExMCP.ACP.Adapters.CodexTest do
       assert codex_response == %{"id" => 99, "result" => %{"decision" => "accept"}}
       assert new_state.pending_client_requests == %{}
     end
+
+    test "structured available decisions round-trip through string ACP option ids", %{
+      state: state
+    } do
+      state = put_test_session(state, "thread-1")
+
+      structured_decision = %{
+        "acceptWithExecpolicyAmendment" => %{
+          "execpolicy_amendment" => ["touch", "/tmp/contract.hwp"]
+        }
+      }
+
+      line =
+        Jason.encode!(%{
+          "id" => 100,
+          "method" => "item/commandExecution/requestApproval",
+          "params" => %{
+            "threadId" => "thread-1",
+            "turnId" => "turn-1",
+            "itemId" => "item-1",
+            "command" => "python3 fill_contract.py",
+            "startedAtMs" => 1,
+            "availableDecisions" => ["accept", structured_decision, "decline"]
+          }
+        })
+
+      assert {:messages, [request], state} = Codex.translate_inbound(line, state)
+
+      assert [accept, structured, decline] = request["params"]["options"]
+      assert accept == %{"optionId" => "accept", "name" => "Accept", "kind" => "allow_once"}
+      assert decline == %{"optionId" => "decline", "name" => "Decline", "kind" => "reject_once"}
+      assert is_binary(structured["optionId"])
+      assert structured["name"] == "Accept With Execpolicy Amendment"
+      assert structured["kind"] == "allow_always"
+
+      response = %{
+        "id" => request["id"],
+        "result" => %{
+          "outcome" => %{"outcome" => "selected", "optionId" => structured["optionId"]}
+        }
+      }
+
+      assert {:ok, data, new_state} = Codex.translate_outbound(response, state)
+
+      assert decode(data) == %{"id" => 100, "result" => %{"decision" => structured_decision}}
+      assert new_state.pending_client_requests == %{}
+    end
+
+    test "fabricated structured option ids are declined instead of forwarded", %{state: state} do
+      state = put_test_session(state, "thread-1")
+
+      available_decision = %{
+        "acceptWithExecpolicyAmendment" => %{
+          "execpolicy_amendment" => ["touch", "/tmp/contract.hwp"]
+        }
+      }
+
+      line =
+        Jason.encode!(%{
+          "id" => 102,
+          "method" => "item/commandExecution/requestApproval",
+          "params" => %{
+            "threadId" => "thread-1",
+            "turnId" => "turn-1",
+            "itemId" => "item-1",
+            "command" => "python3 fill_contract.py",
+            "startedAtMs" => 1,
+            "availableDecisions" => [available_decision]
+          }
+        })
+
+      assert {:messages, [request], state} = Codex.translate_inbound(line, state)
+
+      fabricated_decision = %{
+        "acceptWithExecpolicyAmendment" => %{
+          "execpolicy_amendment" => ["rm", "-rf", "/tmp/contract.hwp"]
+        }
+      }
+
+      fabricated_option_id = "codex:decision:" <> Jason.encode!(fabricated_decision)
+
+      response = %{
+        "id" => request["id"],
+        "result" => %{
+          "outcome" => %{"outcome" => "selected", "optionId" => fabricated_option_id}
+        }
+      }
+
+      assert {:ok, data, new_state} = Codex.translate_outbound(response, state)
+
+      assert decode(data) == %{"id" => 102, "result" => %{"decision" => "decline"}}
+      assert new_state.pending_client_requests == %{}
+    end
+
+    test "deny network policy amendments round-trip as reject-always ACP options", %{
+      state: state
+    } do
+      state = put_test_session(state, "thread-1")
+
+      structured_decision = %{
+        "applyNetworkPolicyAmendment" => %{
+          "network_policy_amendment" => %{"action" => "deny", "host" => "example.test"}
+        }
+      }
+
+      line =
+        Jason.encode!(%{
+          "id" => 101,
+          "method" => "item/commandExecution/requestApproval",
+          "params" => %{
+            "threadId" => "thread-1",
+            "turnId" => "turn-1",
+            "itemId" => "item-1",
+            "command" => "curl https://example.test",
+            "startedAtMs" => 1,
+            "availableDecisions" => [structured_decision]
+          }
+        })
+
+      assert {:messages, [request], state} = Codex.translate_inbound(line, state)
+      assert [structured] = request["params"]["options"]
+      assert is_binary(structured["optionId"])
+      assert structured["name"] == "Apply Network Policy Amendment"
+      assert structured["kind"] == "reject_always"
+
+      response = %{
+        "id" => request["id"],
+        "result" => %{
+          "outcome" => %{"outcome" => "selected", "optionId" => structured["optionId"]}
+        }
+      }
+
+      assert {:ok, data, new_state} = Codex.translate_outbound(response, state)
+
+      assert decode(data) == %{"id" => 101, "result" => %{"decision" => structured_decision}}
+      assert new_state.pending_client_requests == %{}
+    end
   end
 
   defp put_test_session(state, session_id, attrs \\ %{}) do


### PR DESCRIPTION
## What changed

- encode Codex structured approval decisions as ACP-compatible string option IDs
- restore the exact structured decision when the ACP client selects it
- validate structured selections against the original pending `availableDecisions`
- preserve existing string decision behavior

## Why

Codex 0.144.6 can return `acceptWithExecpolicyAmendment` and `applyNetworkPolicyAmendment` objects in `availableDecisions`. The adapter previously passed each decision through `to_string/1`, which crashes for maps and closes the ACP transport.

The validation step also prevents an ACP client from fabricating or altering a persistent execution or network policy amendment that Codex did not offer.

## Validation

- Codex adapter: 35 tests, 0 failures
- Full suite: 15 doctests, 34 properties, 3001 tests, 0 failures (196 excluded)
- `mix format --check-formatted`
- `git diff --check`
