### PR TITLE
Normalize Codex file-change snapshots

### DIFF
--- a/lib/ex_mcp/acp/adapters/codex.ex
+++ b/lib/ex_mcp/acp/adapters/codex.ex
@@ -1050,22 +1050,8 @@ defmodule ExMCP.ACP.Adapters.Codex do
 
   defp handle_notification("item/fileChange/patchUpdated", params, state) do
     session_id = Sessions.id_from_params(params, state)
-    patch = params["patch"] || params
 
-    notification =
-      AdapterEvents.tool_call_update(session_id, %{
-        "toolCallId" => params["callId"] || params["itemId"] || patch["id"],
-        "kind" => "edit",
-        "content" => [
-          Events.tool_diff_content(
-            patch["path"] || params["path"],
-            patch["diff"] || patch["text"] || params["delta"] || ""
-          )
-        ],
-        "rawOutput" => params
-      })
-
-    {:messages, [notification], state}
+    {:messages, [FileChanges.patch_updated(session_id, params)], state}
   end
 
   defp handle_notification("item/mcpToolCall/progress", params, state) do

--- a/lib/ex_mcp/acp/adapters/codex.ex
+++ b/lib/ex_mcp/acp/adapters/codex.ex
@@ -11,7 +11,7 @@ defmodule ExMCP.ACP.Adapters.Codex do
 
   require Logger
 
-  alias ExMCP.ACP.Adapters.Codex.{Config, Events, Sessions, SlashCommands}
+  alias ExMCP.ACP.Adapters.Codex.{Config, Events, FileChanges, Sessions, SlashCommands}
   alias ExMCP.ACP.{AdapterEvents, Envelope, PendingRequests}
   alias ExMCP.Internal.{Maps, NameValue}
 
@@ -1476,16 +1476,7 @@ defmodule ExMCP.ACP.Adapters.Codex do
         {:messages, [notification], state}
 
       "fileChange" ->
-        notification =
-          AdapterEvents.tool_call(session_id, %{
-            "toolCallId" => Events.item_id(params, item),
-            "title" => "Edit File",
-            "kind" => "edit",
-            "status" => Events.normalize_tool_status(item["status"], "in_progress"),
-            "rawInput" => %{"changes" => item["changes"]}
-          })
-
-        {:messages, [notification], state}
+        {:messages, [FileChanges.started(session_id, params, item)], state}
 
       "mcpToolCall" ->
         notification =
@@ -1645,18 +1636,7 @@ defmodule ExMCP.ACP.Adapters.Codex do
   end
 
   defp handle_item_completed(session_id, %{"type" => "fileChange"} = item, state) do
-    changes = item["changes"] || []
-
-    notification =
-      AdapterEvents.tool_call_update(session_id, %{
-        "toolCallId" => item["id"],
-        "kind" => "edit",
-        "status" => Events.normalize_tool_status(item["status"], "completed"),
-        "content" => Enum.map(changes, &Events.file_change_content/1),
-        "rawOutput" => %{"changes" => changes, "status" => item["status"]}
-      })
-
-    {:messages, [notification], state}
+    {:messages, [FileChanges.completed(session_id, item)], state}
   end
 
   defp handle_item_completed(session_id, %{"type" => "mcpToolCall"} = item, state) do

--- a/lib/ex_mcp/acp/adapters/codex/file_changes.ex
+++ b/lib/ex_mcp/acp/adapters/codex/file_changes.ex
@@ -17,9 +17,21 @@ defmodule ExMCP.ACP.Adapters.Codex.FileChanges do
     })
   end
 
+  @spec patch_updated(String.t(), map()) :: map()
+  def patch_updated(session_id, params) do
+    changes = normalize_changes(params["changes"])
+
+    AdapterEvents.tool_call_update(session_id, %{
+      "toolCallId" => Events.item_id(params, %{}),
+      "kind" => "edit",
+      "content" => Enum.map(changes, &Events.file_change_content/1),
+      "rawOutput" => params
+    })
+  end
+
   @spec completed(String.t(), map()) :: map()
   def completed(session_id, item) do
-    changes = item["changes"] || []
+    changes = normalize_changes(item["changes"])
 
     AdapterEvents.tool_call_update(session_id, %{
       "toolCallId" => Events.item_id(%{}, item),
@@ -29,4 +41,7 @@ defmodule ExMCP.ACP.Adapters.Codex.FileChanges do
       "rawOutput" => %{"changes" => changes, "status" => item["status"]}
     })
   end
+
+  defp normalize_changes(changes) when is_list(changes), do: changes
+  defp normalize_changes(_changes), do: []
 end

--- a/lib/ex_mcp/acp/adapters/codex/file_changes.ex
+++ b/lib/ex_mcp/acp/adapters/codex/file_changes.ex
@@ -1,0 +1,32 @@
+defmodule ExMCP.ACP.Adapters.Codex.FileChanges do
+  @moduledoc """
+  Pure mappings for Codex file change lifecycle notifications.
+  """
+
+  alias ExMCP.ACP.AdapterEvents
+  alias ExMCP.ACP.Adapters.Codex.Events
+
+  @spec started(String.t(), map(), map()) :: map()
+  def started(session_id, params, item) do
+    AdapterEvents.tool_call(session_id, %{
+      "toolCallId" => Events.item_id(params, item),
+      "title" => "Edit File",
+      "kind" => "edit",
+      "status" => Events.normalize_tool_status(item["status"], "in_progress"),
+      "rawInput" => %{"changes" => item["changes"]}
+    })
+  end
+
+  @spec completed(String.t(), map()) :: map()
+  def completed(session_id, item) do
+    changes = item["changes"] || []
+
+    AdapterEvents.tool_call_update(session_id, %{
+      "toolCallId" => Events.item_id(%{}, item),
+      "kind" => "edit",
+      "status" => Events.normalize_tool_status(item["status"], "completed"),
+      "content" => Enum.map(changes, &Events.file_change_content/1),
+      "rawOutput" => %{"changes" => changes, "status" => item["status"]}
+    })
+  end
+end

--- a/test/ex_mcp/acp/adapters/codex/file_changes_test.exs
+++ b/test/ex_mcp/acp/adapters/codex/file_changes_test.exs
@@ -56,4 +56,105 @@ defmodule ExMCP.ACP.Adapters.Codex.FileChangesTest do
              }
            ]
   end
+
+  test "patch updated emits every current change as an ordered diff snapshot" do
+    params = %{
+      "itemId" => "edit-1",
+      "changes" => [
+        %{"path" => "lib/a.ex", "newText" => "first"},
+        %{"path" => "lib/b.ex", "diff" => "second"}
+      ]
+    }
+
+    update =
+      "thread-1"
+      |> FileChanges.patch_updated(params)
+      |> get_in(["params", "update"])
+
+    assert update["sessionUpdate"] == "tool_call_update"
+    assert update["toolCallId"] == "edit-1"
+    assert update["kind"] == "edit"
+    assert update["rawOutput"] == params
+
+    assert update["content"] == [
+             %{
+               "type" => "diff",
+               "path" => "lib/a.ex",
+               "oldText" => nil,
+               "newText" => "first"
+             },
+             %{
+               "type" => "diff",
+               "path" => "lib/b.ex",
+               "oldText" => nil,
+               "newText" => "second"
+             }
+           ]
+  end
+
+  test "started patch updated and completed preserve one opaque item identity" do
+    params = %{"itemId" => "opaque-edit", "changes" => []}
+
+    item = %{
+      "type" => "fileChange",
+      "id" => "opaque-edit",
+      "status" => "completed",
+      "changes" => []
+    }
+
+    ids = [
+      FileChanges.started("thread-1", params, item),
+      FileChanges.patch_updated("thread-1", params),
+      FileChanges.completed("thread-1", item)
+    ]
+
+    assert Enum.map(ids, &get_in(&1, ["params", "update", "toolCallId"])) ==
+             List.duplicate("opaque-edit", 3)
+  end
+
+  test "completed and patch updated share ordered content conversion" do
+    changes = [
+      %{"path" => "lib/a.ex", "newText" => "first"},
+      %{"path" => "lib/b.ex", "diff" => "second"}
+    ]
+
+    patch = FileChanges.patch_updated("thread-1", %{"itemId" => "edit-1", "changes" => changes})
+
+    completed =
+      FileChanges.completed("thread-1", %{
+        "type" => "fileChange",
+        "id" => "edit-1",
+        "status" => "completed",
+        "changes" => changes
+      })
+
+    assert get_in(patch, ["params", "update", "content"]) ==
+             get_in(completed, ["params", "update", "content"])
+  end
+
+  test "patch updated treats non-list changes as an empty snapshot" do
+    update =
+      "thread-1"
+      |> FileChanges.patch_updated(%{"itemId" => "edit-1", "changes" => %{"path" => "a"}})
+      |> get_in(["params", "update"])
+
+    assert update["content"] == []
+  end
+
+  test "malformed individual changes use the existing Events fallback" do
+    update =
+      "thread-1"
+      |> FileChanges.patch_updated(%{
+        "itemId" => "edit-1",
+        "changes" => [%{"unexpected" => true}]
+      })
+      |> get_in(["params", "update"])
+
+    assert update["content"] == [
+             %{
+               "type" => "content",
+               "content" => %{"type" => "text", "text" => ~s({"unexpected":true})}
+             }
+           ]
+  end
 end

--- a/test/ex_mcp/acp/adapters/codex/file_changes_test.exs
+++ b/test/ex_mcp/acp/adapters/codex/file_changes_test.exs
@@ -1,0 +1,59 @@
+defmodule ExMCP.ACP.Adapters.Codex.FileChangesTest do
+  use ExUnit.Case, async: true
+
+  alias ExMCP.ACP.Adapters.Codex.FileChanges
+
+  test "started maps the existing file change tool call shape" do
+    params = %{"itemId" => "edit-1"}
+
+    item = %{
+      "type" => "fileChange",
+      "id" => "provider-edit-1",
+      "status" => "running",
+      "changes" => [%{"path" => "lib/a.ex", "diff" => "@@ diff"}]
+    }
+
+    update =
+      "thread-1"
+      |> FileChanges.started(params, item)
+      |> get_in(["params", "update"])
+
+    assert update == %{
+             "sessionUpdate" => "tool_call",
+             "toolCallId" => "edit-1",
+             "title" => "Edit File",
+             "kind" => "edit",
+             "status" => "in_progress",
+             "rawInput" => %{"changes" => item["changes"]}
+           }
+  end
+
+  test "completed maps the existing file change terminal update shape" do
+    item = %{
+      "type" => "fileChange",
+      "id" => "edit-1",
+      "status" => "completed",
+      "changes" => [%{"path" => "lib/a.ex", "newText" => "updated"}]
+    }
+
+    update =
+      "thread-1"
+      |> FileChanges.completed(item)
+      |> get_in(["params", "update"])
+
+    assert update["sessionUpdate"] == "tool_call_update"
+    assert update["toolCallId"] == "edit-1"
+    assert update["kind"] == "edit"
+    assert update["status"] == "completed"
+    assert update["rawOutput"] == %{"changes" => item["changes"], "status" => "completed"}
+
+    assert update["content"] == [
+             %{
+               "type" => "diff",
+               "path" => "lib/a.ex",
+               "oldText" => nil,
+               "newText" => "updated"
+             }
+           ]
+  end
+end

--- a/test/ex_mcp/acp/adapters/codex_test.exs
+++ b/test/ex_mcp/acp/adapters/codex_test.exs
@@ -652,6 +652,30 @@ defmodule ExMCP.ACP.Adapters.CodexTest do
       assert diff["type"] == "diff"
     end
 
+    test "current fileChange patchUpdated reaches the snapshot mapper", %{state: state} do
+      line =
+        Jason.encode!(%{
+          "method" => "item/fileChange/patchUpdated",
+          "params" => %{
+            "threadId" => "thread-1",
+            "itemId" => "edit-1",
+            "changes" => [
+              %{"path" => "lib/a.ex", "newText" => "first"},
+              %{"path" => "lib/b.ex", "diff" => "second"}
+            ]
+          }
+        })
+
+      assert {:messages, [message], ^state} = Codex.translate_inbound(line, state)
+
+      update = get_in(message, ["params", "update"])
+      assert update["sessionUpdate"] == "tool_call_update"
+      assert update["toolCallId"] == "edit-1"
+
+      assert Enum.map(update["content"], &{&1["path"], &1["newText"]}) ==
+               [{"lib/a.ex", "first"}, {"lib/b.ex", "second"}]
+    end
+
     test "token usage is accumulated for the prompt response and emitted as usage_update",
          %{
            state: state


### PR DESCRIPTION
## What changed

- extract Codex `fileChange` lifecycle mapping into `ExMCP.ACP.Adapters.Codex.FileChanges`
- map current `item/fileChange/patchUpdated` payloads from the complete ordered `params.changes` snapshot
- use the same change-to-ACP-content conversion for patch updates and completion
- preserve raw provider payloads for diagnostics

## Why

Current Codex emits `item/fileChange/patchUpdated` with a `changes` list. The adapter still reconstructed one diff from the older singular `patch` shape, so consumers lost later paths and could not replace a file-change snapshot atomically.

This keeps `Codex` responsible for JSON-RPC dispatch and session state, while the new pure helper owns only file-change payload normalization. Snapshot accumulation, deduplication, and file mutation remain outside `ex_mcp`.

## Validation

- `mix test test/ex_mcp/acp/adapters/codex/file_changes_test.exs test/ex_mcp/acp/adapters/codex_test.exs` — 40 passed
- `mix test --warnings-as-errors` — 3,055 passed, 196 excluded; command exits non-zero because the existing upstream suite emits deprecation/type/test-pattern warnings
- `git diff --check` — passed

No ecrits-specific fields, file I/O, patch execution, or snapshot history were added.
