### PR TITLE
Avoid duplicate Claude streamed assistant text

### DIFF
--- a/lib/ex_mcp/acp/adapters/claude_sdk.ex
+++ b/lib/ex_mcp/acp/adapters/claude_sdk.ex
@@ -41,6 +41,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK do
     thinking_acc: [],
     thinking_blocks: [],
     current_block_type: nil,
+    current_assistant_text_streamed?: false,
     tool_calls: %{},
     message_ids: %{}
   ]
@@ -535,6 +536,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK do
         thinking_acc: [],
         thinking_blocks: [],
         current_block_type: nil,
+        current_assistant_text_streamed?: false,
         tool_calls: %{}
     }
   end
@@ -554,6 +556,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK do
               thinking_acc: [],
               thinking_blocks: [],
               current_block_type: nil,
+              current_assistant_text_streamed?: false,
               tool_calls: %{}
           }
 
@@ -596,6 +599,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK do
             thinking_acc: [],
             thinking_blocks: [],
             current_block_type: nil,
+            current_assistant_text_streamed?: false,
             tool_calls: %{}
         }
       else
@@ -619,6 +623,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK do
           thinking_acc: [],
           thinking_blocks: [],
           current_block_type: nil,
+          current_assistant_text_streamed?: false,
           tool_calls: %{}
       }
 

--- a/lib/ex_mcp/acp/adapters/claude_sdk/mapper.ex
+++ b/lib/ex_mcp/acp/adapters/claude_sdk/mapper.ex
@@ -412,7 +412,11 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
   defp handle_stream_event(%{"type" => "content_block_delta", "delta" => delta}, state) do
     case delta do
       %{"type" => "text_delta", "text" => text} ->
-        state = %{state | text_acc: [text | state.text_acc]}
+        state = %{
+          state
+          | text_acc: [text | state.text_acc],
+            current_assistant_text_streamed?: true
+        }
 
         {[AdapterEvents.agent_message_chunk(session_id(state), text)], [], state}
 
@@ -445,21 +449,27 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
       |> maybe_set(:model, message["model"])
       |> maybe_set(:session_id, message["session_id"])
 
-    Enum.reduce(content, {[], [], state}, fn block, {messages, writes, acc} ->
-      {new_messages, new_writes, acc} = handle_assistant_block(block, acc)
-      {messages ++ new_messages, writes ++ new_writes, acc}
-    end)
+    {messages, writes, state} =
+      Enum.reduce(content, {[], [], state}, fn block, {messages, writes, acc} ->
+        {new_messages, new_writes, acc} = handle_assistant_block(block, acc)
+        {messages ++ new_messages, writes ++ new_writes, acc}
+      end)
+
+    {messages, writes, %{state | current_assistant_text_streamed?: false}}
   end
 
-  defp handle_assistant(_message, state), do: {[], [], state}
+  defp handle_assistant(_message, state),
+    do: {[], [], %{state | current_assistant_text_streamed?: false}}
+
+  defp handle_assistant_block(
+         %{"type" => "text"},
+         %{current_assistant_text_streamed?: true} = state
+       ) do
+    {[], [], state}
+  end
 
   defp handle_assistant_block(%{"type" => "text", "text" => text}, state) do
-    state =
-      if state.text_acc == [] do
-        %{state | text_acc: [text]}
-      else
-        state
-      end
+    state = %{state | text_acc: [text | state.text_acc]}
 
     {[AdapterEvents.agent_message_chunk(session_id(state), text)], [], state}
   end
@@ -573,6 +583,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
         thinking_acc: [],
         thinking_blocks: [],
         current_block_type: nil,
+        current_assistant_text_streamed?: false,
         session_id: session_id
     }
 
@@ -1241,6 +1252,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
               thinking_acc: [],
               thinking_blocks: [],
               current_block_type: nil,
+              current_assistant_text_streamed?: false,
               tool_calls: %{}
           }
 

--- a/test/ex_mcp/acp/adapters/claude_sdk_test.exs
+++ b/test/ex_mcp/acp/adapters/claude_sdk_test.exs
@@ -496,6 +496,181 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDKTest do
       assert state.session_id == "s1"
     end
 
+    test "does not re-emit terminal assistant text after partial text chunks", %{state: state} do
+      start_event = %{
+        "type" => "stream_event",
+        "session_id" => "s1",
+        "event" => %{
+          "type" => "content_block_start",
+          "content_block" => %{"type" => "text", "text" => ""}
+        }
+      }
+
+      delta_event = %{
+        "type" => "stream_event",
+        "session_id" => "s1",
+        "event" => %{
+          "type" => "content_block_delta",
+          "delta" => %{"type" => "text_delta", "text" => "streamed once"}
+        }
+      }
+
+      assistant_event = %{
+        "type" => "assistant",
+        "session_id" => "s1",
+        "message" => %{
+          "content" => [%{"type" => "text", "text" => "streamed once"}]
+        }
+      }
+
+      assert {:skip, state} =
+               ClaudeSDK.translate_inbound(Jason.encode!(start_event), state)
+
+      assert {:messages, [chunk], state} =
+               ClaudeSDK.translate_inbound(Jason.encode!(delta_event), state)
+
+      assert get_in(chunk, ["params", "update", "content", "text"]) == "streamed once"
+
+      assert {:skip, state} =
+               ClaudeSDK.translate_inbound(Jason.encode!(assistant_event), state)
+
+      assert IO.iodata_to_binary(Enum.reverse(state.text_acc)) == "streamed once"
+    end
+
+    test "does not re-emit streamed text when the terminal assistant also contains a tool", %{
+      state: state
+    } do
+      text_start = %{
+        "type" => "stream_event",
+        "session_id" => "s1",
+        "event" => %{
+          "type" => "content_block_start",
+          "content_block" => %{"type" => "text", "text" => ""}
+        }
+      }
+
+      text_delta = %{
+        "type" => "stream_event",
+        "session_id" => "s1",
+        "event" => %{
+          "type" => "content_block_delta",
+          "delta" => %{"type" => "text_delta", "text" => "before tool"}
+        }
+      }
+
+      tool = %{
+        "type" => "tool_use",
+        "id" => "toolu_read",
+        "name" => "Read",
+        "input" => %{"file_path" => "/tmp/project/lib/a.ex"}
+      }
+
+      tool_start = %{
+        "type" => "stream_event",
+        "session_id" => "s1",
+        "event" => %{"type" => "content_block_start", "content_block" => tool}
+      }
+
+      assistant = %{
+        "type" => "assistant",
+        "session_id" => "s1",
+        "message" => %{
+          "content" => [%{"type" => "text", "text" => "before tool"}, tool]
+        }
+      }
+
+      assert {:skip, state} = ClaudeSDK.translate_inbound(Jason.encode!(text_start), state)
+
+      assert {:messages, [_chunk], state} =
+               ClaudeSDK.translate_inbound(Jason.encode!(text_delta), state)
+
+      assert {:messages, [_pending], state} =
+               ClaudeSDK.translate_inbound(Jason.encode!(tool_start), state)
+
+      assert {:messages, messages, state} =
+               ClaudeSDK.translate_inbound(Jason.encode!(assistant), state)
+
+      refute Enum.any?(
+               messages,
+               &(get_in(&1, ["params", "update", "sessionUpdate"]) ==
+                   "agent_message_chunk")
+             )
+
+      assert IO.iodata_to_binary(Enum.reverse(state.text_acc)) == "before tool"
+    end
+
+    test "allows assistant-only text after a streamed assistant", %{state: state} do
+      text_start = %{
+        "type" => "stream_event",
+        "session_id" => "s1",
+        "event" => %{
+          "type" => "content_block_start",
+          "content_block" => %{"type" => "text", "text" => ""}
+        }
+      }
+
+      text_delta = %{
+        "type" => "stream_event",
+        "session_id" => "s1",
+        "event" => %{
+          "type" => "content_block_delta",
+          "delta" => %{"type" => "text_delta", "text" => "first"}
+        }
+      }
+
+      streamed_assistant = %{
+        "type" => "assistant",
+        "session_id" => "s1",
+        "message" => %{"content" => [%{"type" => "text", "text" => "first"}]}
+      }
+
+      fallback_assistant = %{
+        "type" => "assistant",
+        "session_id" => "s1",
+        "message" => %{"content" => [%{"type" => "text", "text" => " fallback"}]}
+      }
+
+      assert {:skip, state} = ClaudeSDK.translate_inbound(Jason.encode!(text_start), state)
+
+      assert {:messages, [_chunk], state} =
+               ClaudeSDK.translate_inbound(Jason.encode!(text_delta), state)
+
+      assert {:skip, state} =
+               ClaudeSDK.translate_inbound(Jason.encode!(streamed_assistant), state)
+
+      assert {:messages, [fallback_chunk], state} =
+               ClaudeSDK.translate_inbound(Jason.encode!(fallback_assistant), state)
+
+      assert get_in(fallback_chunk, ["params", "update", "content", "text"]) == " fallback"
+      assert IO.iodata_to_binary(Enum.reverse(state.text_acc)) == "first fallback"
+    end
+
+    test "accumulates every assistant text block when no partials were streamed", %{
+      state: state
+    } do
+      assistant = %{
+        "type" => "assistant",
+        "session_id" => "s1",
+        "message" => %{
+          "content" => [
+            %{"type" => "text", "text" => "first"},
+            %{"type" => "text", "text" => " second"}
+          ]
+        }
+      }
+
+      assert {:messages, messages, state} =
+               ClaudeSDK.translate_inbound(Jason.encode!(assistant), state)
+
+      chunks =
+        for %{"params" => %{"update" => %{"sessionUpdate" => "agent_message_chunk"} = update}} <-
+              messages,
+            do: get_in(update, ["content", "text"])
+
+      assert chunks == ["first", " second"]
+      assert IO.iodata_to_binary(Enum.reverse(state.text_acc)) == "first second"
+    end
+
     test "final result produces ACP prompt response with stop reason and usage", %{state: state} do
       state = %{state | pending_prompt_id: 123, session_id: "s1", text_acc: ["world", "hello "]}
 


### PR DESCRIPTION
## What changed

- Track whether the current Claude assistant response already emitted text deltas.
- Suppress only the duplicate terminal assistant text snapshot while preserving tool blocks.
- Reset the marker at response, cancellation, cleanup, and prompt boundaries.
- Cover streamed text, mixed text/tool responses, terminal-only fallback, and multiple terminal text blocks.

## Why

With `--include-partial-messages`, Claude's stream JSON emits incremental `text_delta` events and then a terminal `assistant` record containing the same full text. The adapter mapped both forms to appendable ACP `agent_message_chunk` updates, so clients rendered the answer twice.

The mapper now treats the terminal text as a snapshot when deltas already supplied that response's text. Non-streaming assistant records still emit normally, and terminal tool blocks remain visible.

## Impact

ACP consumers receive one logical assistant text stream from Claude without requiring client-side deduplication. Existing terminal-only and tool-use behavior remains intact.

## Validation

- Upstream `master` baseline: 24 Claude SDK adapter tests passed before cherry-picking the fix.
- `mix test test/ex_mcp/acp/adapters/claude_sdk_test.exs`: 28 tests, 0 failures.
- `mix test test/ex_mcp/acp`: 348 tests, 0 failures.
- `MIX_ENV=test mix compile --warnings-as-errors`: passed.
