### PR TITLE
perf(auth): reduce FullOAuthFlow verification time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Full OAuth flow verification no longer expands broad inferred error and map
+  unions that made compiling the module take minutes under Elixir 1.20.
 - The external MCP conformance client now round-trips complete JSON Schema
   2020-12 tool schemas without replacing them with generated arguments.
 - The Pi adapter now waits for `agent_settled` before completing an ACP prompt,

--- a/lib/ex_mcp/authorization/full_oauth_flow.ex
+++ b/lib/ex_mcp/authorization/full_oauth_flow.ex
@@ -111,6 +111,8 @@ defmodule ExMCP.Authorization.FullOAuthFlow do
           end
 
         run_and_persist_token(as_metadata, client_info, config)
+      else
+        {:error, _reason} = error -> error
       end
 
     case result do
@@ -144,6 +146,8 @@ defmodule ExMCP.Authorization.FullOAuthFlow do
     with {:ok, token_data} <- select_and_run_grant_flow(as_metadata, client_info, config),
          :ok <- persist_token(token_data, as_metadata, client_info, config) do
       {:ok, Map.put(token_data, :authorization_server_issuer, as_metadata["issuer"])}
+    else
+      {:error, _reason} = error -> error
     end
   end
 
@@ -367,19 +371,15 @@ defmodule ExMCP.Authorization.FullOAuthFlow do
     case Map.get(data, "authorization_servers", []) do
       issuers when is_list(issuers) ->
         if Enum.all?(issuers, &(is_binary(&1) and &1 != "")) do
-          result = %{authorization_servers: Enum.map(issuers, &%{issuer: &1})}
+          resource = if is_binary(data["resource"]), do: data["resource"], else: nil
+          scopes = if is_list(data["scopes_supported"]), do: data["scopes_supported"], else: nil
 
-          result =
-            if is_binary(data["resource"]),
-              do: Map.put(result, :resource, data["resource"]),
-              else: result
-
-          result =
-            if is_list(data["scopes_supported"]),
-              do: Map.put(result, :scopes_supported, data["scopes_supported"]),
-              else: result
-
-          {:ok, result}
+          {:ok,
+           %{
+             authorization_servers: Enum.map(issuers, &%{issuer: &1}),
+             resource: resource,
+             scopes_supported: scopes
+           }}
         else
           {:error, :invalid_prm_metadata}
         end
@@ -627,6 +627,8 @@ defmodule ExMCP.Authorization.FullOAuthFlow do
              {:ok, body} <-
                build_client_credentials_body(client_info, config, token_auth_method) do
           HTTPClient.make_token_request(token_endpoint, body, auth_method: token_auth_method)
+        else
+          {:error, _reason} = error -> error
         end
 
       case result do
@@ -639,7 +641,7 @@ defmodule ExMCP.Authorization.FullOAuthFlow do
 
           {:ok, token_data}
 
-        error ->
+        {:error, _reason} = error ->
           error
       end
     end
@@ -799,9 +801,11 @@ defmodule ExMCP.Authorization.FullOAuthFlow do
 
           {:ok, token_data}
 
-        error ->
+        {:error, _reason} = error ->
           error
       end
+    else
+      {:error, _reason} = error -> error
     end
   end
 
@@ -880,6 +884,8 @@ defmodule ExMCP.Authorization.FullOAuthFlow do
         body,
         auth_method: token_auth_method
       )
+    else
+      {:error, _reason} = error -> error
     end
   end
 

--- a/test/ex_mcp/authorization/full_oauth_flow_credential_store_test.exs
+++ b/test/ex_mcp/authorization/full_oauth_flow_credential_store_test.exs
@@ -99,6 +99,35 @@ defmodule ExMCP.Authorization.FullOAuthFlowCredentialStoreTest do
     assert Agent.get(server.counter, & &1.registrations) == 0
   end
 
+  test "treats malformed optional PRM fields as absent" do
+    {:ok, store_agent} =
+      Agent.start_link(fn -> %{index: %{}, registrations: %{}, tokens: %{}} end)
+
+    server =
+      oauth_server("client-with-malformed-prm", nil,
+        prm_resource: 42,
+        prm_scopes: "not-a-list"
+      )
+
+    assert {:ok, %{access_token: "token-for-client-with-malformed-prm"}} =
+             server
+             |> flow_config({StoreAdapter, store_agent})
+             |> FullOAuthFlow.execute()
+  end
+
+  test "preserves token endpoint errors across the client credentials flow" do
+    {:ok, store_agent} =
+      Agent.start_link(fn -> %{index: %{}, registrations: %{}, tokens: %{}} end)
+
+    response = %{"error" => "invalid_client", "error_description" => "credentials rejected"}
+    server = oauth_server("rejected-client", nil, token_error: response)
+
+    assert {:error, {:oauth_error, 401, ^response}} =
+             server
+             |> flow_config({StoreAdapter, store_agent})
+             |> FullOAuthFlow.execute()
+  end
+
   test "preserves native and web DCR redirect rejections without a weakening retry" do
     {:ok, store_agent} =
       Agent.start_link(fn -> %{index: %{}, registrations: %{}, tokens: %{}} end)
@@ -255,6 +284,7 @@ defmodule ExMCP.Authorization.FullOAuthFlowCredentialStoreTest do
           {^resource_host, "/prm"} ->
             %{"authorization_servers" => [issuer]}
             |> maybe_put("resource", opts[:prm_resource])
+            |> maybe_put("scopes_supported", opts[:prm_scopes])
 
           {^issuer_host, "/.well-known/openid-configuration"} ->
             %{
@@ -300,12 +330,18 @@ defmodule ExMCP.Authorization.FullOAuthFlowCredentialStoreTest do
     Bypass.stub(bypass, "POST", "/token", fn conn ->
       Agent.update(counter, &Map.update!(&1, :tokens, fn count -> count + 1 end))
 
-      json(conn, 200, %{
-        "access_token" => "token-for-#{client_id}",
-        "token_type" => "Bearer",
-        "expires_in" => 3_600,
-        "scope" => "tools:read"
-      })
+      case opts[:token_error] do
+        nil ->
+          json(conn, 200, %{
+            "access_token" => "token-for-#{client_id}",
+            "token_type" => "Bearer",
+            "expires_in" => 3_600,
+            "scope" => "tools:read"
+          })
+
+        error ->
+          json(conn, 401, error)
+      end
     end)
 
     %{


### PR DESCRIPTION
Closes #19.

## Summary
- narrow OAuth flow error boundaries to the documented `{:error, reason}` shape
- construct protected-resource metadata with a stable map shape
- cover malformed optional PRM metadata and token endpoint error propagation

## Local verification
- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix credo --strict`
- `mix dialyzer`
- `mix test` (3,823 tests, 20 doctests, 34 properties; 0 failures)

The key acceptance check is the Elixir 1.20 CI compile duration, which was about 268 seconds before this patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth error matching and PRM parsing. Behavior is mostly type-narrowing, but a missed error shape could change how token or metadata failures surface.
> 
> **Overview**
> Cuts Elixir 1.20 compile time for `FullOAuthFlow` by pinning `with`/`case` error arms to `{:error, reason}` instead of inferred catch-all unions.
> 
> Protected-resource metadata now always uses a fixed map (`resource` and `scopes_supported` may be `nil`). Malformed optional PRM fields are treated as absent, and client-credentials token errors keep their original `{:oauth_error, ...}` shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23974b1625607d2803c13e51a5cc26ef23341198. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->