### PR TITLE
release: 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ACP reference pins advanced to Claude Agent ACP `7c66108` and Codex ACP `4823131`. The Codex 1.7.0 permission/mode parity below is ported; the later upstream changes the pins now cover (Claude stable mode catalog with `_meta.kind` and Auto-mode fallback, per-model token usage, deferred steering, native subagents/async tasks, and session forks; Codex native subagent sessions, session forks, and session title generation) are not yet implemented and are tracked in `docs/POST_1_0_MAINTENANCE_PLAN.md` as pending parity decisions.
 - Codex ACP adapter 1.7.0 permission/mode parity: `approvalsReviewer`, mode `_meta.kind`, and TS permission presentation.
 - Extracted `ExMCP.ACP.Adapters.Codex.Protocol` for native app-server envelopes, method names, response classification, and request-id correlation.
 - Extracted `ExMCP.ACP.Adapters.Pi.RPC` for native RPC envelopes, correlation ids, and response classification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-09-02
+
 ### Added
 
 - Claude Code `tools: []` now passes `--tools ""` so the CLI disables built-in tools. Empty allow/deny lists still mean no opinion.

--- a/docs/POST_1_0_MAINTENANCE_PLAN.md
+++ b/docs/POST_1_0_MAINTENANCE_PLAN.md
@@ -1,11 +1,12 @@
 # Post-1.0 Maintenance Plan
 
-- **Status:** Stable 1.0 packaging work complete; larger maintenance items remain
+- **Status:** Stable 1.0 packaging and the focused contract cleanup are
+  complete; adapter modularization and functional-core extraction remain
   proposed and tracked
 - **Baseline:** ExMCP `1.0.0`
 - **Scope:** behavior-preserving modularization, functional-core extraction,
   dependency cleanup, and Hex source-package cleanup
-- **Last updated:** 2026-08-22
+- **Last updated:** 2026-09-02
 
 This is a repository-maintenance document, not user-facing package
 documentation. It records cleanup that is valuable but too invasive to mix
@@ -205,6 +206,32 @@ chosen explicitly before changing code:
 | Client capability detection | Resource operations inspect the process dictionary's `$initial_call` to infer a modern client. | Replace the heuristic with an explicit internal connection-info or capability query. | Eligible for 1.x only with identical results for all supported client entry points. |
 | Ambient inputs | Several paths read application/system environment, current directory, time, or generate IDs inside decision code. | Normalize configuration once at startup and pass resolved values into cores. | Internal injection is eligible for 1.x if precedence and generated wire values remain identical; precedence changes are 2.0-only. |
 
+### Status as of 2026-09-02
+
+Each row above was resolved on `master` after 1.1.1 and ships in 1.2.0 unless
+noted:
+
+- **Circuit breaker clocks:** resolved. `CircuitBreaker.Core` receives an
+  injected monotonic `now_ms` from the process shell and no longer reads wall
+  time for elapsed durations.
+- **Session storage option:** resolved as a contract plus adapter. A standalone
+  1.x store-adapter ADR and ETS-only contract suite were accepted,
+  `SessionManager` dispatches through an internal `SessionStore` seam, an
+  opt-in DETS backend (`storage_backend: :dets` with `:storage_path`) is
+  available, and `:persistent_term` remains accepted with a warning that it
+  uses ETS. ETS is still the default and its restart-empty behavior is
+  unchanged.
+- **Client fallback:** resolved as a documentation correction. `ExMCP.connect/2`
+  now documents that only the first spec of a list is used; the list form stays
+  accepted throughout 1.x.
+- **Stdio logging:** the VM-global hazard is documented for 1.x. Replacing the
+  behavior remains a 2.0 item.
+- **Client capability detection:** resolved. Resource subscribe/unsubscribe
+  decide modern versus legacy from `Client.get_status` protocol version behind
+  an explicit Client process marker; `$initial_call` is no longer inspected.
+- **Ambient inputs:** open. The clock injection above is the first instance;
+  remaining reads are handled case by case under the same 1.x rule.
+
 ## Dependency-direction cleanup
 
 At commit `4591af6`, `mix xref graph --format stats` reports eight dependency
@@ -360,6 +387,30 @@ These are genuine unreleased behavior changes rather than repository-move
 noise. Keeping the reviewed commits pinned makes the scheduled drift check
 continue to report the work until parity is deliberately accepted or ported.
 
+### 2026-09-01 pin refresh and remaining parity decisions
+
+The manifest was subsequently advanced to Claude Agent ACP
+`7c6610835f26f18cd162b78dff74a7b7cd74497a` and Codex ACP
+`4823131475b3b0d996ccc305e49dcf9fdaa6ee52`; Pi ACP is unchanged. The Codex
+1.7.0 permission and mode parity work (`approvalsReviewer`, mode `_meta.kind`,
+and TypeScript-style permission presentation) is ported with tests and covers
+the two Codex commits listed above. The pins now lead the reviewed behavior,
+so the drift check no longer reports the following upstream changes; each
+still needs an explicit parity decision and, where accepted, characterized
+adapter work before it is claimed as supported:
+
+- Claude `caf609b` stable mode catalog with `_meta.kind` and the Auto-mode
+  fallback to Accept edits with a client-visible warning;
+- Claude per-model token usage on prompt responses, deferred steering while
+  user input is pending, native subagents and async tasks, and
+  message-specific ACP session forks;
+- Codex native ACP subagent sessions, ACP session forks, and AI session title
+  generation with a `/rename` command.
+
+Record the decision for each item here before the next pin refresh; a pin
+that leads the reviewed behavior must not be advanced again until this list is
+resolved.
+
 ## ACP v1 completion and v2 monitoring
 
 The July 2026 stable ACP v1 additions are represented in the runtime and
@@ -393,11 +444,14 @@ existing, disabled-by-default Codex legacy compatibility option.
 2. Qualify and publish rc.8, then run the fresh final-candidate soak. **Complete.**
 3. Release stable 1.0 with no adapter decomposition mixed into the release diff. **Complete.**
 4. Resolve the focused contract mismatches as small correctness or documentation
-   changes.
+   changes. **Complete for the 1.x lane** (see the status list above); ambient
+   input injection continues case by case.
 5. Extract the shared HTTP reducer and the smallest high-value functional cores
    behind characterization tests.
-6. Modularize Codex one characterized boundary at a time.
-7. Modularize Pi one characterized boundary at a time.
+6. Modularize Codex one characterized boundary at a time. `Codex.Protocol` is
+   extracted; `Sessions`, `Permissions`, `Content`, and `MCP` remain.
+7. Modularize Pi one characterized boundary at a time. `Pi.RPC` is extracted;
+   `Sessions`, `Events`, `PromptFlow`, and `Config` remain.
 8. Reduce dependency cycles without changing public or lifecycle semantics.
 9. Re-evaluate shared app-server pieces while preparing the post-1.0 ZCode
    adapter; keep vendor-specific protocol semantics separate by default.

--- a/docs/V2_ROADMAP.md
+++ b/docs/V2_ROADMAP.md
@@ -2,7 +2,7 @@
 
 - **Status:** Living roadmap — Phase 0 complete; Phase 1 contract design is next
 - **Target:** ExMCP `2.0.0`, after stable `1.0.0` and the supported 1.x line
-- **Last updated:** 2026-08-22
+- **Last updated:** 2026-09-02
 - **Related release work:** [`RELEASE_1_0_0.md`](./RELEASE_1_0_0.md),
   [`API_DIFF_RC5_TO_1_0.md`](./API_DIFF_RC5_TO_1_0.md),
   [`POST_1_0_MAINTENANCE_PLAN.md`](./POST_1_0_MAINTENANCE_PLAN.md),
@@ -348,6 +348,9 @@ Planned removals include:
 
 - `ExMCP.Server.Tools`, `Tools.Simplified`, and their companion modules after
   the DSL migration path is verified;
+- `ExMCP.Transport.HTTPServer` and `ExMCP.Transport.HTTPServerWithVersion`, the
+  simplified example transport deprecated in 1.2.0 in favour of
+  `ExMCP.HttpPlug`;
 - deprecated image transformation stubs that are outside MCP/ACP scope;
 - retained aliases and compatibility functions that have a documented 2.0
   replacement; and
@@ -409,7 +412,10 @@ another 1.x RC or document a patch-level correctness/security exception.
 | Correct bounded replay-buffer retention | Released in `1.0.0` | Correctness fix with regression coverage. |
 | Documentation, examples, diagnostics, and characterization tests | Backport | No runtime compatibility cost. |
 | Additive dispatch telemetry | Eligible for a 1.x minor | Preserve existing events; bounded metadata only; payload capture opt-in. |
-| Store adapter seam | Possible later 1.x minor | Only after a standalone store ADR and contract suite are accepted; the design need not wait for 2.0 runtime implementation. ETS must remain the default and current behavior unchanged. |
+| Store adapter seam | Released in `1.2.0` | The standalone store ADR and ETS contract suite were accepted first. `SessionManager` dispatches through an internal `SessionStore` seam with an opt-in DETS backend; ETS remains the default and existing behavior is unchanged. |
+| Circuit breaker monotonic clock injection | Released in `1.2.0` | Characterized correctness fix; timeout and telemetry behavior preserved. |
+| Explicit client protocol-version query replacing `$initial_call` | Released in `1.2.0` | Identical results for every supported client entry point. |
+| `HttpPlug` body fallback, mount-independent routing, and terminal halt | Released in `1.2.0` | Documented bug fixes with regression tests; no wire change. |
 | Internal dispatch deduplication | Case by case | Backport only when golden tests prove identical wire, errors, ordering, and lifecycle. |
 | Richer DSL constraints | Hold for 2.0 | Additive, but expands the stable public language before its design is settled. |
 | Result facade and client lifecycle helpers | Hold for 2.0 | Technically additive, but would create parallel APIs and long-term support obligations. |

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExMCP.MixProject do
   use Mix.Project
 
-  @version "1.1.1"
+  @version "1.2.0"
   @github_url "https://github.com/azmaveth/ex_mcp"
 
   def project do

--- a/test/ex_mcp/client_beam_transport_test.exs
+++ b/test/ex_mcp/client_beam_transport_test.exs
@@ -280,14 +280,8 @@ defmodule ExMCP.ClientBeamTransportTest do
     end
   end
 
-  defp stop_if_alive(pid) when is_pid(pid) do
-    # Elixir 1.20 deprecates the implicit try form for catch.
-    # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
-    try do
-      if Process.alive?(pid), do: GenServer.stop(pid)
-    catch
-      :exit, :noproc -> :ok
-      :exit, {:noproc, _} -> :ok
-    end
-  end
+  # The server is linked to the test process, so it can already be shutting
+  # down when on_exit runs; `safe_stop_process/1` swallows every exit reason,
+  # not only :noproc.
+  defp stop_if_alive(pid) when is_pid(pid), do: ExMCP.TestHelpers.safe_stop_process(pid)
 end

--- a/test/ex_mcp/integration/mrtr_round_trip_test.exs
+++ b/test/ex_mcp/integration/mrtr_round_trip_test.exs
@@ -84,7 +84,7 @@ defmodule ExMCP.Integration.MRTRRoundTripTest do
         request_state: [active_key_id: "integration", keys: %{"integration" => @key}]
       )
 
-    on_exit(fn -> if Process.alive?(server), do: GenServer.stop(server) end)
+    on_exit(fn -> ExMCP.TestHelpers.safe_stop_process(server) end)
 
     {:ok, client} =
       Client.start_link(


### PR DESCRIPTION
## Summary

Prepares the 1.2.0 release from everything merged to master since v1.1.1, plus the planning-doc refresh that the roadmap's own rules ask for before a 1.x backport ships.

### Release commit
- `mix.exs` version `1.1.1` → `1.2.0`.
- CHANGELOG: the Unreleased section becomes `[1.2.0] - 2026-09-02`. It is a minor because it carries additive features (opt-in DETS session store with the internal store seam, Claude `tools: []` → `--tools ""`, Codex ACP 1.7.0 permission/mode parity) and a deprecation (`ExMCP.Transport.HTTPServer` / `HTTPServerWithVersion`), alongside the HttpPlug fixes from #27 and #28, the circuit-breaker clock injection, and the `$initial_call` replacement.

### Planning-doc refresh
- `docs/POST_1_0_MAINTENANCE_PLAN.md`: status header; a dated status list under the focused-contract-cleanup table recording that five of six rows are resolved on master; `Codex.Protocol` and `Pi.RPC` marked as the first extracted boundaries; a new "2026-09-01 pin refresh and remaining parity decisions" section listing the upstream Claude and Codex changes the advanced ACP pins now cover but the adapters do not implement, with a rule not to advance the pins again until each has a decision.
- `docs/V2_ROADMAP.md`: section 8.2 gains "Released in 1.2.0" rows for the store adapter seam, clock injection, client capability query, and HttpPlug fixes; the Phase 6 removal list adds the deprecated HTTPServer transport.
- CHANGELOG Changed entry recording the pin advance and the unported upstream work, so the silent pin move becomes a recorded decision.

### Deliberately not included
- The Cowlib advisory exception in `mix.exs` keeps its 2026-09-12 review deadline. No patched Cowlib is on Hex, the fix is only on upstream master, and the maintainer's stated policy is cadenced releases. The deadline stays as the trigger to decide whether Cowlib remains a required dependency (see #18 and the Bandit draft #21).
- Claude adapter parity for the post-pin upstream changes; tracked in the maintenance plan instead.

## Test plan
- [x] `mix hex.build` produces `ex_mcp-1.2.0.tar`
- [x] `mix hex.audit` passes with the existing named exceptions only
- [x] `mix docs` with `warnings_as_errors`
- [x] `mix format --check-formatted`; pre-commit hook ran dialyzer clean
- [ ] CI matrix on this PR
- [ ] After merge: tag `v1.2.0` on the squash commit and publish to Hex

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhntZBTtX9MzmxRE2JnnPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhntZBTtX9MzmxRE2JnnPK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and documentation only in this diff; runtime behavior was merged earlier. Test cleanup is low-risk harness hardening.
> 
> **Overview**
> **Cuts release 1.2.0** by setting `mix.exs` to `1.2.0` and moving the existing **Unreleased** changelog into **`[1.2.0] - 2026-09-02`**, documenting what already shipped on master (HttpPlug fixes, session store seam / opt-in DETS, circuit-breaker monotonic clock, client capability detection, Codex 1.7.0 parity, HTTPServer deprecation, etc.).
> 
> **Updates maintainer docs** so they match that release: `POST_1_0_MAINTENANCE_PLAN` marks focused contract cleanup as largely complete, records ACP pin advances and **unported** upstream parity work, and notes `Codex.Protocol` / `Pi.RPC` extractions; `V2_ROADMAP` lists 1.2.0 backports and adds deprecated HTTPServer modules to the Phase 6 removal list.
> 
> **Test teardown** in two integration tests now calls `ExMCP.TestHelpers.safe_stop_process/1` instead of ad hoc `GenServer.stop` / try-catch, so linked servers shutting down during `on_exit` do not flake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00832ed3818d2531a4419de366ad7fa4b231d400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->