### PR TITLE
fix: make SSESession.init/0 safe under concurrent first calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ExMCP.Server.SSESession.init/0` is safe under concurrent first calls. Two requests racing to create the named ETS table made the loser raise `ArgumentError`, which the gating MCP 2026-07-28 conformance run hit intermittently in `server-sse-multiple-streams`. The conformance server now creates the table once at startup from its long-lived main process instead of on every request.
 - `HttpPlug` rejects `GET`/`DELETE` in `:modern_only` mode with `405` at its mount root wherever it is mounted. The check compared the absolute request path with the `:path` option (default `/mcp`), so a router `forward` at any other prefix (the README's `/api/mcp` mount) answered `404` and `400` instead.
 - `HttpPlug` halts the conn after responding, as a terminal plug should. Mounting it directly in an endpoint no longer needs a manual `halt/1`.
 - `HttpPlug` no longer answers `-32700 Parse error` when an upstream `Plug.Parsers` has already drained the request body, which is what the README's Phoenix router mount does on every stock endpoint. It now falls back to the payload Phoenix parsed (`conn.body_params`) for JSON requests carrying a non-empty object. An empty body, a non-JSON content type, and a `%{"_json" => ...}` wrapper (a top-level array) keep their previous behaviour, and `conn.assigns[:raw_body]` still takes precedence when set.

--- a/lib/ex_mcp/server/sse_session.ex
+++ b/lib/ex_mcp/server/sse_session.ex
@@ -34,11 +34,28 @@ defmodule ExMCP.Server.SSESession do
   @default_wait_for_stream 3_000
   @wait_poll_ms 25
 
-  @doc "Initialize the session ETS table."
+  @doc """
+  Initialize the session ETS table.
+
+  Idempotent and safe to call concurrently: the first caller creates the table
+  and every other caller, including one that races the creator, is a no-op.
+  The table is owned by the process that creates it, so call this once from a
+  long-lived process such as the server's startup code, not from a
+  per-request process whose exit would drop the table.
+  """
   @spec init() :: :ok
   def init do
-    if :ets.info(@ets_table) == :undefined do
-      :ets.new(@ets_table, [:set, :public, :named_table, read_concurrency: true])
+    if :ets.whereis(@ets_table) == :undefined do
+      try do
+        :ets.new(@ets_table, [:set, :public, :named_table, read_concurrency: true])
+      rescue
+        error in ArgumentError ->
+          # Another process created the table between the check and
+          # `:ets.new/2`. Anything else is a real error.
+          if :ets.whereis(@ets_table) == :undefined do
+            reraise error, __STACKTRACE__
+          end
+      end
     end
 
     :ok

--- a/test/conformance/server.exs
+++ b/test/conformance/server.exs
@@ -756,8 +756,6 @@ defmodule ConformanceRouter do
 
   @impl true
   def call(conn, _opts) do
-    SSESession.init()
-
     # DNS rebinding protection
     conn = DnsRebinding.call(conn, DnsRebinding.init([]))
     if conn.halted, do: conn, else: route(conn)
@@ -1183,6 +1181,11 @@ end
 
 port = String.to_integer(List.first(System.argv(), "3001"))
 IO.puts("Starting ExMCP conformance server on port #{port}...")
+
+# Create the SSE session table once, owned by this long-lived script process.
+# Creating it lazily from request processes raced concurrent first requests
+# (server-sse-multiple-streams) and tied the table's life to a single request.
+ExMCP.Server.SSESession.init()
 
 children = [{Plug.Cowboy, scheme: :http, plug: ConformanceRouter, options: [port: port]}]
 {:ok, _} = Supervisor.start_link(children, strategy: :one_for_one)

--- a/test/ex_mcp/server/sse_session_test.exs
+++ b/test/ex_mcp/server/sse_session_test.exs
@@ -1,0 +1,59 @@
+defmodule ExMCP.Server.SSESessionTest do
+  # The session table is a VM-global named ETS table.
+  use ExUnit.Case, async: false
+
+  alias ExMCP.Server.SSESession
+
+  @table :ex_mcp_sse_sessions
+
+  setup do
+    assert :ets.whereis(@table) == :undefined,
+           "another owner left #{inspect(@table)} behind"
+
+    :ok
+  end
+
+  test "init/0 is idempotent from one process" do
+    assert :ok = SSESession.init()
+    assert :ok = SSESession.init()
+    assert :ets.info(@table, :owner) == self()
+    :ets.delete(@table)
+  end
+
+  test "init/0 tolerates concurrent first callers" do
+    # Repeat the race so a regression to check-then-create is caught reliably.
+    for _round <- 1..20 do
+      parent = self()
+
+      racers =
+        for _ <- 1..64 do
+          spawn_link(fn ->
+            receive do
+              :go -> :ok
+            end
+
+            send(parent, {:init_result, self(), SSESession.init()})
+
+            receive do
+              :stop -> :ok
+            end
+          end)
+        end
+
+      Enum.each(racers, &send(&1, :go))
+
+      for _ <- racers do
+        assert_receive {:init_result, _pid, :ok}, 5_000
+      end
+
+      owner = :ets.info(@table, :owner)
+      assert owner in racers
+
+      # The table dies with its owner, which resets the race for the next round.
+      ref = Process.monitor(owner)
+      Enum.each(racers, &send(&1, :stop))
+      assert_receive {:DOWN, ^ref, :process, ^owner, _reason}, 5_000
+      assert :ets.whereis(@table) == :undefined
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Root cause of the `MCP 2026-07-28 external conformance` failure on master run 326 (`a9fbb8c`, the 1.2.0 release commit), which passed on re-run. Bundled into 1.2.0 since the release is not published yet.

- `ExMCP.Server.SSESession.init/0` checked `:ets.info/1` and then called `:ets.new/2` for the named table. Two concurrent first requests both passed the check and the loser raised `ArgumentError: table name already exists`. The conformance server's log shows exactly that in two request processes at the moment `server-sse-multiple-streams` opened parallel streams.
- `init/0` now uses `:ets.whereis/1`, creates the table, and treats a concurrent creation as success; any other `ArgumentError` is re-raised. Its docs now say to call it once from a long-lived process.
- The conformance server (`test/conformance/server.exs`) called `init/0` from `call/2` on every request, which also made the table die with whichever request created it. It now creates the table once at startup from the script's main process.
- New `test/ex_mcp/server/sse_session_test.exs` races 64 processes twenty times. It fails against the previous implementation with the same `ArgumentError` and passes with the fix.
- CHANGELOG: entry added under `[1.2.0]` Fixed.

`SSESession` has no callers under `lib/` other than itself; today only the conformance server uses it.

## Test plan
- [x] `mix test test/ex_mcp/server/sse_session_test.exs` passes 3/3 runs; fails against the old `init/0`
- [x] `mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors`; pre-commit hook ran dialyzer clean
- [x] CI matrix on this PR, in particular the external conformance job
- [ ] After merge: tag `v1.2.0` on the new squash commit (the local tag from earlier pointed at `a9fbb8c` and was never pushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhntZBTtX9MzmxRE2JnnPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhntZBTtX9MzmxRE2JnnPK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow ETS initialization and conformance-server startup change; behavior is idempotent with added regression tests and no production lib callers beyond the fixture pattern documented in moduledoc.
> 
> **Overview**
> Fixes an intermittent **`ArgumentError` (table name already exists)** when parallel requests both tried to create the global `:ex_mcp_sse_sessions` ETS table—seen in MCP conformance **`server-sse-multiple-streams`**.
> 
> **`ExMCP.Server.SSESession.init/0`** now uses `:ets.whereis/1` and treats a concurrent `:ets.new/2` `ArgumentError` as success when the table already exists; docs stress calling it once from a **long-lived owner**, not per-request processes.
> 
> The **conformance fixture** stops calling `init/0` on every Plug request and initializes the table **once at script startup** so the table is not tied to a short-lived request process.
> 
> Adds **`sse_session_test.exs`** (idempotent `init/0` and 64-way concurrent first-caller races) and a **CHANGELOG** Fixed entry for 1.2.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5580c0853f907edf1c0af41d0eb147cc539cf2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->