### PR TITLE
feat(acp): preserve original messages in optional client callbacks

### DIFF
--- a/docs/ACP_GUIDE.md
+++ b/docs/ACP_GUIDE.md
@@ -409,6 +409,24 @@ outside those roots, including escapes through existing symlinks. Nonexistent
 children below a trusted root are permitted so write/create handlers can work;
 custom handlers remain responsible for rechecking policy at the point of use.
 
+### Original message context
+
+Handlers can also implement `handle_session_update/4` and
+`handle_permission_request/5`. These optional variants receive the original
+decoded JSON-RPC message immediately before the handler state argument. When a
+variant is present, ExMCP calls it instead of the corresponding legacy callback.
+Keep the legacy callbacks to support older ExMCP versions.
+
+The message retains unknown top-level and parameter fields and the original
+permission request ID. It is a decoded map, not the original JSON bytes.
+ExMCP performs validation and session authorization before dispatch. It still
+owns request correlation, cancellation, and handler deadlines. Return the same
+permission outcome as before; ExMCP builds the response.
+
+Both variants run through the existing handler runner. Retained update message
+data counts toward `:max_update_queue_bytes`, including fields outside the
+update. Legacy handlers and the event-listener message format are unchanged.
+
 ### Event Listener
 
 For simple use cases, receive session updates as process messages instead of implementing a full handler:

--- a/docs/ACP_GUIDE.md
+++ b/docs/ACP_GUIDE.md
@@ -409,16 +409,24 @@ outside those roots, including escapes through existing symlinks. Nonexistent
 children below a trusted root are permitted so write/create handlers can work;
 custom handlers remain responsible for rechecking policy at the point of use.
 
-### Original message context
+### ACP message context
 
 Handlers can also implement `handle_session_update/4` and
-`handle_permission_request/5`. These optional variants receive the original
-decoded JSON-RPC message immediately before the handler state argument. When a
-variant is present, ExMCP calls it instead of the corresponding legacy callback.
-Keep the legacy callbacks to support older ExMCP versions.
+`handle_permission_request/5`. These optional variants receive the decoded
+JSON-RPC message that reached the ACP client, immediately before the handler
+state argument. When a variant is present, ExMCP calls it instead of the
+corresponding legacy callback. Keep the legacy callbacks to support older
+ExMCP versions.
 
-The message retains unknown top-level and parameter fields and the original
-permission request ID. It is a decoded map, not the original JSON bytes.
+The message retains unknown top-level and parameter fields and the permission
+request ID from the received ACP message. It is a decoded map, not the original
+JSON bytes. This callback does not provide an unmodified native-provider event.
+For a native ACP agent, the value is the message that the agent wrote. For an
+agent used through `ExMCP.ACP.AdapterTransport`, `AdapterBridge` and the adapter
+construct the ACP message from the agent's native protocol. Native fields that
+the adapter does not map are already absent. An adapter can include selected
+native data in ACP extension fields when its contract supports that data.
+
 ExMCP performs validation and session authorization before dispatch. It still
 owns request correlation, cancellation, and handler deadlines. Return the same
 permission outcome as before; ExMCP builds the response.

--- a/lib/ex_mcp/acp/client.ex
+++ b/lib/ex_mcp/acp/client.ex
@@ -590,7 +590,12 @@ defmodule ExMCP.ACP.Client do
   end
 
   def handle_info({:transport_message, raw_message}, state) do
-    state = raw_message |> Protocol.parse_message() |> handle_parsed_message(state)
+    state =
+      case Protocol.parse_message_with_context(raw_message) do
+        {:ok, parsed, message} -> handle_parsed_message(parsed, state, message)
+        error -> handle_parsed_message(error, state)
+      end
+
     {:noreply, state}
   end
 
@@ -699,17 +704,11 @@ defmodule ExMCP.ACP.Client do
 
   def handle_info(_msg, state), do: {:noreply, state}
 
-  defp handle_parsed_message({:result, result, id}, state),
-    do: resolve_pending(id, {:ok, result}, state)
-
-  defp handle_parsed_message({:error, error, id}, state),
-    do: resolve_pending(id, {:error, error}, state)
-
-  defp handle_parsed_message({:notification, "session/update", params}, state) do
+  defp handle_parsed_message({:notification, "session/update", params}, state, message) do
     case RequestValidation.validate_session_update(params) do
       :ok ->
         if authorized_session_id?(params["sessionId"], state) do
-          handle_session_update(params, state)
+          handle_session_update(params, state, message)
         else
           Logger.warning("ACP client ignored an update for an unknown session")
           state
@@ -720,6 +719,17 @@ defmodule ExMCP.ACP.Client do
         state
     end
   end
+
+  defp handle_parsed_message({:request, method, params, id}, state, message),
+    do: validate_and_handle_agent_request(method, params, id, state, message)
+
+  defp handle_parsed_message(parsed, state, _message), do: handle_parsed_message(parsed, state)
+
+  defp handle_parsed_message({:result, result, id}, state),
+    do: resolve_pending(id, {:ok, result}, state)
+
+  defp handle_parsed_message({:error, error, id}, state),
+    do: resolve_pending(id, {:error, error}, state)
 
   defp handle_parsed_message({:notification, "$/cancel_request", params}, state),
     do: handle_cancel_request_notification(params, state)
@@ -737,9 +747,6 @@ defmodule ExMCP.ACP.Client do
 
     state
   end
-
-  defp handle_parsed_message({:request, method, params, id}, state),
-    do: validate_and_handle_agent_request(method, params, id, state)
 
   defp handle_parsed_message(other, state) do
     Logger.debug("ACP client received unexpected message",
@@ -1263,7 +1270,7 @@ defmodule ExMCP.ACP.Client do
     }
   end
 
-  defp handle_session_update(params, state) do
+  defp handle_session_update(params, state, message) do
     session_id = params["sessionId"]
     update = params["update"]
     update_bytes = :erlang.external_size(update)
@@ -1290,7 +1297,8 @@ defmodule ExMCP.ACP.Client do
         session_id,
         update,
         state.max_update_queue,
-        state.max_update_queue_bytes
+        state.max_update_queue_bytes,
+        handler_message(state, :handle_session_update, 4, message)
       )
     end
 
@@ -1348,13 +1356,13 @@ defmodule ExMCP.ACP.Client do
 
   defp clear_abandoned_prompt_text(_pending, state), do: state
 
-  defp validate_and_handle_agent_request(method, params, id, state) do
+  defp validate_and_handle_agent_request(method, params, id, state, message) do
     with :ok <- ensure_agent_request_id_available(id, state),
          :ok <- ensure_advertised_client_capability(method, params, state),
          :ok <- RequestValidation.validate_agent_request(method, params),
          :ok <- ensure_agent_session_authority(method, params, state),
          :ok <- ensure_agent_request_capacity(state) do
-      handle_agent_request(method, params, id, state)
+      handle_agent_request(method, params, id, state, message)
     else
       {:error, :duplicate_request_id} ->
         send_agent_request_error(state, id, -32_600, "Request id is already in use")
@@ -1514,20 +1522,36 @@ defmodule ExMCP.ACP.Client do
     state
   end
 
-  defp handle_agent_request("session/request_permission", params, id, state) do
+  defp handle_agent_request("session/request_permission", params, id, state, message) do
     session_id = params["sessionId"]
     tool_call = params["toolCall"]
     options = params["options"] || []
 
     if state.handler_pid do
       ref = make_ref()
-      HandlerRunner.permission_request(state.handler_pid, ref, session_id, tool_call, options)
+
+      HandlerRunner.permission_request(
+        state.handler_pid,
+        ref,
+        session_id,
+        tool_call,
+        options,
+        handler_message(state, :handle_permission_request, 5, message)
+      )
+
       track_agent_request(state, ref, :permission, id, session_id)
     else
       response = Protocol.encode_error(-32603, "Handler unavailable", nil, id)
       send_to_transport(response, state)
       state
     end
+  end
+
+  defp handle_agent_request(method, params, id, state, _message),
+    do: handle_agent_request(method, params, id, state)
+
+  defp handler_message(state, callback, arity, message) do
+    if function_exported?(state.handler_mod, callback, arity), do: message
   end
 
   defp handle_agent_request("elicitation/create", params, id, state) do

--- a/lib/ex_mcp/acp/client/handler.ex
+++ b/lib/ex_mcp/acp/client/handler.ex
@@ -24,6 +24,22 @@ defmodule ExMCP.ACP.Client.Handler do
               {:ok, state()}
 
   @doc """
+  Handles a session update with its original decoded JSON-RPC message.
+
+  When implemented, this optional callback is called instead of
+  `c:handle_session_update/3`. The message retains unknown top-level and
+  parameter fields. It is the decoded map, not the original JSON bytes.
+  ExMCP validates the update and session before dispatch. Message data counts
+  toward the existing handler update queue byte limit.
+  """
+  @callback handle_session_update(
+              session_id :: String.t(),
+              update :: map(),
+              message :: map(),
+              state()
+            ) :: {:ok, state()}
+
+  @doc """
   Called when the agent requests permission to use a tool.
 
   Must return an outcome map with an `"optionId"` matching one of the
@@ -33,6 +49,23 @@ defmodule ExMCP.ACP.Client.Handler do
               session_id :: String.t(),
               tool_call :: map(),
               options :: [map()],
+              state()
+            ) :: {:ok, outcome :: map(), state()}
+
+  @doc """
+  Handles a permission request with its original decoded JSON-RPC message.
+
+  When implemented, this optional callback is called instead of
+  `c:handle_permission_request/4`. The message includes the original request
+  ID and all received fields. ExMCP retains request correlation, validation,
+  cancellation, and timeout ownership. Return the same outcome as the legacy
+  callback; do not send a JSON-RPC response from the handler.
+  """
+  @callback handle_permission_request(
+              session_id :: String.t(),
+              tool_call :: map(),
+              options :: [map()],
+              message :: map(),
               state()
             ) :: {:ok, outcome :: map(), state()}
 
@@ -87,6 +120,8 @@ defmodule ExMCP.ACP.Client.Handler do
   @callback terminate(reason :: any(), state()) :: :ok
 
   @optional_callbacks [
+    handle_session_update: 4,
+    handle_permission_request: 5,
     handle_file_read: 4,
     handle_file_write: 4,
     handle_terminal_request: 4,

--- a/lib/ex_mcp/acp/client/handler.ex
+++ b/lib/ex_mcp/acp/client/handler.ex
@@ -24,11 +24,19 @@ defmodule ExMCP.ACP.Client.Handler do
               {:ok, state()}
 
   @doc """
-  Handles a session update with its original decoded JSON-RPC message.
+  Handles a session update with the decoded JSON-RPC message received by the
+  ACP client.
 
   When implemented, this optional callback is called instead of
   `c:handle_session_update/3`. The message retains unknown top-level and
-  parameter fields. It is the decoded map, not the original JSON bytes.
+  parameter fields from the ACP message. It is the decoded map, not the
+  original JSON bytes.
+
+  This is an ACP-boundary value. A native ACP agent supplies the message. When
+  the client uses `ExMCP.ACP.AdapterTransport`, `ExMCP.ACP.AdapterBridge` and
+  the selected adapter construct the ACP message from the agent's native
+  protocol. Native fields that the adapter does not map are not present.
+
   ExMCP validates the update and session before dispatch. Message data counts
   toward the existing handler update queue byte limit.
   """
@@ -53,13 +61,16 @@ defmodule ExMCP.ACP.Client.Handler do
             ) :: {:ok, outcome :: map(), state()}
 
   @doc """
-  Handles a permission request with its original decoded JSON-RPC message.
+  Handles a permission request with the decoded JSON-RPC message received by
+  the ACP client.
 
   When implemented, this optional callback is called instead of
   `c:handle_permission_request/4`. The message includes the original request
   ID and all received fields. ExMCP retains request correlation, validation,
   cancellation, and timeout ownership. Return the same outcome as the legacy
-  callback; do not send a JSON-RPC response from the handler.
+  callback; do not send a JSON-RPC response from the handler. This callback
+  has the same ACP-boundary limit as `c:handle_session_update/4`: an adapted
+  agent can supply only the fields that its adapter placed in the ACP request.
   """
   @callback handle_permission_request(
               session_id :: String.t(),

--- a/lib/ex_mcp/acp/client/handler_runner.ex
+++ b/lib/ex_mcp/acp/client/handler_runner.ex
@@ -30,10 +30,14 @@ defmodule ExMCP.ACP.Client.HandlerRunner do
   end
 
   def session_update(pid, session_id, update, max_queue, max_queue_bytes) do
-    incoming_bytes = :erlang.external_size(update)
+    session_update(pid, session_id, update, max_queue, max_queue_bytes, nil)
+  end
+
+  def session_update(pid, session_id, update, max_queue, max_queue_bytes, message) do
+    incoming_bytes = update_size(update, message)
 
     if update_mailbox_below_limits?(pid, max_queue, max_queue_bytes, incoming_bytes) do
-      GenServer.cast(pid, {:session_update, session_id, update})
+      GenServer.cast(pid, {:session_update, session_id, update, message})
       :ok
     else
       :dropped
@@ -62,10 +66,20 @@ defmodule ExMCP.ACP.Client.HandlerRunner do
   defp queued_update_size({:"$gen_cast", {:session_update, _session_id, update}}),
     do: :erlang.external_size(update)
 
+  defp queued_update_size({:"$gen_cast", {:session_update, _session_id, update, message}}),
+    do: update_size(update, message)
+
   defp queued_update_size(_message), do: 0
 
+  defp update_size(update, nil), do: :erlang.external_size(update)
+  defp update_size(update, message), do: :erlang.external_size({update, message})
+
   def permission_request(pid, ref, session_id, tool_call, options) do
-    GenServer.cast(pid, {:permission_request, ref, session_id, tool_call, options})
+    permission_request(pid, ref, session_id, tool_call, options, nil)
+  end
+
+  def permission_request(pid, ref, session_id, tool_call, options, message) do
+    GenServer.cast(pid, {:permission_request, ref, session_id, tool_call, options, message})
   end
 
   def file_read(pid, ref, session_id, path, opts) do
@@ -109,8 +123,12 @@ defmodule ExMCP.ACP.Client.HandlerRunner do
 
   @impl true
   def handle_cast({:session_update, session_id, update}, state) do
+    handle_cast({:session_update, session_id, update, nil}, state)
+  end
+
+  def handle_cast({:session_update, session_id, update, message}, state) do
     case safe_call(fn ->
-           state.handler_mod.handle_session_update(session_id, update, state.handler_state)
+           call_with_context(state, :handle_session_update, [session_id, update], message)
          end) do
       {:ok, {:ok, handler_state}} ->
         {:noreply, %{state | handler_state: handler_state}}
@@ -129,13 +147,17 @@ defmodule ExMCP.ACP.Client.HandlerRunner do
   end
 
   def handle_cast({:permission_request, ref, session_id, tool_call, options}, state) do
+    handle_cast({:permission_request, ref, session_id, tool_call, options, nil}, state)
+  end
+
+  def handle_cast({:permission_request, ref, session_id, tool_call, options, message}, state) do
     {result, state} =
       case safe_call(fn ->
-             state.handler_mod.handle_permission_request(
-               session_id,
-               tool_call,
-               options,
-               state.handler_state
+             call_with_context(
+               state,
+               :handle_permission_request,
+               [session_id, tool_call, options],
+               message
              )
            end) do
         {:ok, {:ok, outcome, handler_state}} ->
@@ -262,6 +284,15 @@ defmodule ExMCP.ACP.Client.HandlerRunner do
     end
 
     :ok
+  end
+
+  defp call_with_context(state, callback, args, message) do
+    args =
+      if is_map(message) and function_exported?(state.handler_mod, callback, length(args) + 2),
+        do: args ++ [message, state.handler_state],
+        else: args ++ [state.handler_state]
+
+    apply(state.handler_mod, callback, args)
   end
 
   defp safe_call(fun) do

--- a/lib/ex_mcp/acp/protocol.ex
+++ b/lib/ex_mcp/acp/protocol.ex
@@ -42,9 +42,9 @@ defmodule ExMCP.ACP.Protocol do
           | {:error, map(), integer() | String.t() | nil}
           | {:error, :invalid_message}
   def parse_message(data) when is_binary(data) do
-    case Jason.decode(data) do
-      {:ok, decoded} -> parse_message(decoded)
-      {:error, _} -> {:error, :invalid_message}
+    case parse_message_with_context(data) do
+      {:ok, parsed, _message} -> parsed
+      error -> error
     end
   end
 
@@ -68,6 +68,21 @@ defmodule ExMCP.ACP.Protocol do
   end
 
   def parse_message(_), do: {:error, :invalid_message}
+
+  @doc false
+  def parse_message_with_context(data) when is_binary(data) do
+    case Jason.decode(data) do
+      {:ok, decoded} when is_map(decoded) -> parse_message_with_context(decoded)
+      _ -> {:error, :invalid_message}
+    end
+  end
+
+  def parse_message_with_context(message) do
+    case parse_message(message) do
+      {:error, :invalid_message} = error -> error
+      parsed -> {:ok, parsed, message}
+    end
+  end
 
   defp mixed_request_response?(message) do
     (Map.has_key?(message, "method") and

--- a/test/ex_mcp/acp/client_message_context_test.exs
+++ b/test/ex_mcp/acp/client_message_context_test.exs
@@ -1,0 +1,231 @@
+defmodule ExMCP.ACP.ClientMessageContextTest do
+  use ExUnit.Case, async: true
+
+  alias ExMCP.ACP.Agent.Transport.Memory
+  alias ExMCP.ACP.Client
+
+  defmodule ContextHandler do
+    @behaviour ExMCP.ACP.Client.Handler
+
+    @impl true
+    def init(opts), do: {:ok, %{parent: Keyword.fetch!(opts, :parent), sequence: 0}}
+
+    @impl true
+    def handle_session_update(session_id, update, state) do
+      send(state.parent, {:legacy_update, session_id, update})
+      {:ok, state}
+    end
+
+    @impl true
+    def handle_session_update(session_id, update, message, state) do
+      send(state.parent, {:context_update, session_id, update, message, state.sequence})
+      {:ok, %{state | sequence: state.sequence + 1}}
+    end
+
+    @impl true
+    def handle_permission_request(_session_id, _tool_call, _options, state) do
+      send(state.parent, :legacy_permission)
+      {:ok, %{"outcome" => "cancelled"}, state}
+    end
+
+    @impl true
+    def handle_permission_request(session_id, tool_call, options, message, state) do
+      send(state.parent, {:context_permission, self(), session_id, tool_call, options, message})
+
+      receive do
+        {:permission_outcome, outcome} -> {:ok, outcome, state}
+      after
+        2_000 -> {:ok, %{"outcome" => "cancelled"}, state}
+      end
+    end
+  end
+
+  test "preserves complete decoded messages and callback ordering without changing event listeners" do
+    {client, _transport} = start_client(event_listener: self())
+    first = update_message("first")
+    second = update_message("second")
+    update = first["params"]["update"]
+
+    send(client, {:transport_message, Jason.encode!(first)})
+    send(client, {:transport_message, second})
+
+    assert_receive {:context_update, "context-session", ^update, ^first, 0}
+    assert_receive {:context_update, "context-session", _, ^second, 1}
+    assert_receive {:acp_session_update, "context-session", ^update}
+    refute_receive {:legacy_update, _, _}
+  end
+
+  test "preserves permission context and response correlation while rejecting duplicate IDs" do
+    {_client, transport} = start_client()
+    request = permission_message("original-id")
+    send_raw(transport, request)
+    assert_receive {:context_permission, handler, "context-session", tool_call, options, ^request}
+    assert tool_call == request["params"]["toolCall"]
+    assert options == request["params"]["options"]
+
+    send_raw(transport, request)
+    assert %{"id" => "original-id", "error" => %{"code" => -32_600}} = receive_raw(transport)
+    refute_receive {:context_permission, _, _, _, _, _}
+    refute_receive :legacy_permission
+
+    outcome = %{"outcome" => "selected", "optionId" => "allow"}
+    send(handler, {:permission_outcome, outcome})
+    assert %{"id" => "original-id", "result" => %{"outcome" => ^outcome}} = receive_raw(transport)
+  end
+
+  test "context-aware permission handlers retain timeout and late-response behavior" do
+    {client, transport} = start_client(handler_request_timeout: 50)
+    request = permission_message(nil)
+    send_raw(transport, request)
+    assert_receive {:context_permission, handler, _, _, _, ^request}
+
+    assert %{"id" => nil, "error" => %{"message" => "Client handler timed out"}} =
+             receive_raw(transport)
+
+    assert :sys.get_state(client).pending_agent_requests == %{}
+
+    send(handler, {:permission_outcome, %{"outcome" => "cancelled"}})
+    :sys.get_state(handler)
+    state = :sys.get_state(client)
+    assert state.pending_agent_requests == %{}
+    assert :queue.is_empty(:sys.get_state(transport.peer).queues.agent)
+  end
+
+  test "malformed and unauthorized messages never reach context callbacks" do
+    {client, transport} = start_client()
+    valid = update_message("valid")
+
+    for invalid <- [
+          "{invalid",
+          Jason.encode!(Jason.encode!(valid)),
+          Map.put(valid, "jsonrpc", "1.0"),
+          put_in(valid, ["params", "sessionId"], "unknown"),
+          put_in(valid, ["params", "update"], %{})
+        ] do
+      send(client, {:transport_message, invalid})
+    end
+
+    request = put_in(permission_message(7), ["params", "sessionId"], "unknown")
+    send_raw(transport, request)
+    assert %{"id" => 7, "error" => %{"code" => -32_602}} = receive_raw(transport)
+    refute_receive {:context_update, _, _, _, _}
+    refute_receive {:context_permission, _, _, _, _, _}
+  end
+
+  test "handler queue byte limits include unknown envelope fields" do
+    {client, _transport} = start_client(max_update_queue: 100, max_update_queue_bytes: 2_000)
+    handler = :sys.get_state(client).handler_pid
+    :ok = :sys.suspend(handler)
+
+    message = Map.put(update_message("small update"), "extension", String.duplicate("x", 1_000))
+    send(client, {:transport_message, message})
+    :sys.get_state(client)
+    assert {:message_queue_len, 1} = Process.info(handler, :message_queue_len)
+
+    for _ <- 1..5, do: send(client, {:transport_message, message})
+    :sys.get_state(client)
+    assert {:message_queue_len, 1} = Process.info(handler, :message_queue_len)
+    :ok = :sys.resume(handler)
+    assert_receive {:context_update, _, _, ^message, 0}
+  end
+
+  test "context updates retain the handler queue count limit" do
+    {client, _transport} = start_client(max_update_queue: 2)
+    handler = :sys.get_state(client).handler_pid
+    :ok = :sys.suspend(handler)
+    for index <- 1..10, do: send(client, {:transport_message, update_message(to_string(index))})
+    :sys.get_state(client)
+    assert {:message_queue_len, 2} = Process.info(handler, :message_queue_len)
+    :ok = :sys.resume(handler)
+    assert_receive {:context_update, _, _, _, 0}
+    assert_receive {:context_update, _, _, _, 1}
+    refute_receive {:context_update, _, _, _, 2}
+  end
+
+  defp start_client(opts \\ []) do
+    {:ok, peer} = Memory.new_pair()
+    {:ok, transport} = Memory.connect(peer: peer, role: :agent)
+
+    handshake =
+      Task.async(fn ->
+        %{"id" => id, "method" => "initialize"} = receive_raw(transport)
+
+        send_raw(transport, %{
+          "jsonrpc" => "2.0",
+          "id" => id,
+          "result" => %{
+            "protocolVersion" => 1,
+            "agentCapabilities" => %{},
+            "authMethods" => []
+          }
+        })
+
+        %{"id" => id, "method" => "session/new"} = receive_raw(transport)
+
+        send_raw(transport, %{
+          "jsonrpc" => "2.0",
+          "id" => id,
+          "result" => %{"sessionId" => "context-session"}
+        })
+      end)
+
+    {:ok, client} =
+      Client.start_link(
+        Keyword.merge(
+          [
+            transport_mod: Memory,
+            peer: peer,
+            role: :client,
+            handler: ContextHandler,
+            handler_opts: [parent: self()]
+          ],
+          opts
+        )
+      )
+
+    assert {:ok, %{"sessionId" => "context-session"}} = Client.new_session(client, "/tmp")
+    Task.await(handshake)
+    {client, transport}
+  end
+
+  defp update_message(text) do
+    %{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "extension" => %{"trace" => text},
+      "params" => %{
+        "sessionId" => "context-session",
+        "extra" => [1, 2],
+        "update" => %{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => text},
+          "providerExtension" => true
+        }
+      }
+    }
+  end
+
+  defp permission_message(id) do
+    %{
+      "jsonrpc" => "2.0",
+      "id" => id,
+      "method" => "session/request_permission",
+      "extension" => %{"trace" => "permission"},
+      "params" => %{
+        "sessionId" => "context-session",
+        "extra" => "retained",
+        "toolCall" => %{"toolCallId" => "tool-1"},
+        "options" => [%{"optionId" => "allow", "name" => "Allow", "kind" => "allow_once"}]
+      }
+    }
+  end
+
+  defp send_raw(transport, message) do
+    assert {:ok, _} = Memory.send_message(Jason.encode!(message), transport)
+  end
+
+  defp receive_raw(transport) do
+    assert {:ok, message, _} = Memory.receive_message(transport)
+    Jason.decode!(message)
+  end
+end


### PR DESCRIPTION
ACP client handlers previously received selected update and permission fields. Consumers could not retain unknown fields elsewhere in the received JSON-RPC message. Jido Harness needs that ACP data in `Event.raw` while ExMCP keeps protocol parsing and request correlation.

This adds optional `handle_session_update/4` and `handle_permission_request/5` callbacks. The new argument is the decoded JSON-RPC map received by the ACP client. ExMCP calls the context variant when present and uses the existing callback otherwise. Only one callback runs for each event.

This is an ACP-boundary value. A native ACP agent supplies it. When a client uses `AdapterTransport`, `AdapterBridge` and the selected adapter construct the ACP message from the native protocol before the client receives it. Native fields that the adapter does not map are absent. This change preserves the complete received ACP envelope; it does not expose an unmodified native-provider event. The Handler documentation and ACP guide state this limit.

- Decode and validate once, retain the original map, and dispatch only after session and request checks.
- Carry context through the existing handler runner. Count retained update context against the queue byte limit, including unknown envelope fields.
- Preserve event-listener messages, old handler modules, permission outcomes, request IDs, cancellation, and timeouts.
- Reject a JSON string that contains encoded JSON instead of decoding it again as a protocol object.

Validation on Elixir 1.19.5 / OTP 28.3.1:

- Targeted ACP client, protocol, null-ID, compatibility, and message-context tests: 148 passed.
- Full default suite with `--exclude compliance --max-cases 4`: 3,392 tests, 20 doctests, 34 properties; no failures; 804 excluded.
- The first full run at default concurrency hit an existing native Agent null-ID timeout assertion. The targeted run and full four-worker run passed.
- Strict Credo, Dialyzer, compilation with warnings as errors, documentation with warnings as errors, Hex package build, and dependency audit passed locally. The repository's existing Cowlib advisory exceptions are unchanged.

PR #32 merged as `d43ef8e3c996448f5bb75b83165b611b642360fd` on 2026-09-04. The merge tree matches the reviewed PR head. The [merge workflow](https://github.com/azmaveth/ex_mcp/actions/runs/33924345887) passed coverage, compliance, interop, Dialyzer, and the Elixir 1.18, 1.19, and 1.20 jobs. Its Elixir 1.17 audit job found two Mint 1.9.3 advisories. Its performance job stopped in an existing native `:code_server` failure.

Downstream integration is in [Jido Harness PR #64](https://github.com/agentjido/jido_harness/pull/64). Harness head `cde6fdf360514d9ef9f4e38f7b1b3101d4706ce3` pins the official ExMCP merge in both its dependency declaration and lockfile. Harness also selects Mint 1.10.0, which removes the two Mint findings from its audit.

Downstream proof on 2026-09-04, Elixir 1.20.3 / OTP 29.0.5:

- A separate application with only the Harness Git dependency passed two integration tests for finite runs, session loading, complete received ACP update and permission messages, journal omission, policy approvals, stale replies, and process cleanup.
- Amp, Codex, Grok, and OpenCode each passed two live turns in that application. The checks verified context recall, stable processes and provider sessions, received ACP JSON-RPC maps on all 42 output events, Harness turn IDs, ordered replay, raw-data omission, and cleanup. No managed process remained. Five providers need credentials or renewed login and remain live-unverified.
- A local signed Hex repository supplied test packages built from the reviewed runtime source to a fresh consumer. All 21 dependency locks were Hex entries. Installed ExMCP and Harness runtime files matched their source snapshots. Both consumer integration tests passed. No package was published.

ExMCP 1.2.0 remains the latest Hex release and does not contain this merge. Harness uses the official Git commit until a release contains it. Its actual Hex package gate stays open until then.

Closes #31
