### PR TITLE
feat(acp): nest adapter _meta under ex_mcp and tag native event provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handler deadlines are unchanged. For adapted agents the message is the ACP envelope
   the adapter constructed, not the native provider event (#31, #32).
 
+- `_meta.ex_mcp.native` on every ACP message an adapter derives from a native agent
+  line: the adapter `name` and a per-connection `sequence`, plus the decoded native
+  `event` when `AdapterTransport`/`AdapterBridge` is started with `native_events: :raw`
+  (`:summary` is the default, `:off` disables the block). Adapters can implement the new
+  optional `ExMCP.ACP.Adapter.name/0` callback; the bridge derives a name from the module
+  otherwise.
+
 ### Changed
 
+- **BREAKING:** Adapter extension data now lives under nested `_meta.ex_mcp.<adapter>`
+  maps everywhere. The Claude SDK adapter previously used a flat `"ex_mcp.claude_sdk"`
+  key, and the Codex, Pi, and ZCode capability advertisements used flat `"ex_mcp.codex"`,
+  `"ex_mcp.pi"`, and `"ex_mcp.zcode"` keys. Consumers reading those keys must read
+  `_meta["ex_mcp"]["claude_sdk"]` (and so on) instead; the documented dotted paths such
+  as `_meta.ex_mcp.claude_sdk.sessionId` are unchanged and now match the wire shape.
 - `ExMCP.ACP.Protocol.parse_message/1` rejects a JSON string that contains encoded JSON
   instead of decoding it a second time (#32).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `handle_session_update/3` and `handle_permission_request/4` on
+  `ExMCP.ACP.Client.Handler` are now optional, so a handler can implement only the
+  context-aware arities. A handler must still export at least one arity of each pair;
+  the client refuses to start one that does not, with
+  `{:handler_init_failed, {:missing_callback, name}}`. Existing handlers are unaffected.
 - **BREAKING:** Adapter extension data now lives under nested `_meta.ex_mcp.<adapter>`
   maps everywhere. The Claude SDK adapter previously used a flat `"ex_mcp.claude_sdk"`
   key, and the Codex, Pi, and ZCode capability advertisements used flat `"ex_mcp.codex"`,

--- a/docs/ACP_GUIDE.md
+++ b/docs/ACP_GUIDE.md
@@ -180,6 +180,7 @@ The adapter launches `zcode app-server`. Set `adapter_opts[:cli_path]` or the
 | `:handler_request_timeout` | `30_000` | Maximum lifetime for inbound handler callbacks |
 | `:max_update_queue` | `32` | Mailbox cutoff for handler and event-listener session updates; excess updates are dropped |
 | `:max_outbox_bytes` | `4_194_304` | Aggregate byte limit for an adapter bridge's undelivered messages |
+| `:native_events` | `:summary` | Adapter-bridged agents only: `_meta.ex_mcp.native` detail on derived messages (`:off`, `:summary`, or `:raw` to embed the decoded native event) |
 | `:name` | `nil` | GenServer name registration |
 
 ### Boolean Config Options
@@ -435,6 +436,11 @@ Both variants run through the existing handler runner. Retained update message
 data counts toward `:max_update_queue_bytes`, including fields outside the
 update. Legacy handlers and the event-listener message format are unchanged.
 
+For an adapted agent, the retained message already carries `_meta.ex_mcp.native`
+with the adapter name and sequence. Start the transport with
+`native_events: :raw` to also receive the decoded native provider event there;
+see "`_meta.ex_mcp` namespaces" below.
+
 ### Event Listener
 
 For simple use cases, receive session updates as process messages instead of implementing a full handler:
@@ -474,6 +480,25 @@ Adapter-specific status, error, and extension bridge details are attached under
 `_meta.ex_mcp` on spec-defined update types, usually `session_info_update`.
 Content chunks may include ACP's optional `messageId` field so clients can group
 streamed chunks into logical messages.
+
+### `_meta.ex_mcp` namespaces
+
+ExMCP keeps all of its extension data under one `_meta.ex_mcp` map so other ACP
+implementations can ignore it as a unit:
+
+| Key | Set by | Contents |
+|-----|--------|----------|
+| `_meta.ex_mcp.<adapter>` | The adapter (`claude_sdk`, `codex`, `pi`, `zcode`) | Provider-specific fields the adapter chose to surface, such as Claude Code's session UUID, tool names, cost, or auth errors |
+| `_meta.ex_mcp.native` | `AdapterBridge` | Provenance of the ACP message: the adapter `name`, a per-connection `sequence` number, and with `native_events: :raw` the decoded native `event` |
+| `_meta.ex_mcp.mcpCapabilities.beam` | Capability negotiation | BEAM-local MCP transport support |
+
+The `native` block is attached to every ACP message an adapter derives from one
+native agent line, so all messages from the same line share a `sequence`. Pass
+`native_events: :raw` to `AdapterTransport` (or `AdapterBridge`) to embed the
+full native event, `:off` to drop the block entirely. Raw events can be large;
+they count toward the client's `:max_update_queue_bytes` like any other
+retained update data. Adapters implement `c:ExMCP.ACP.Adapter.name/0` to name
+their namespace; the bridge derives it from the module name otherwise.
 
 ## Writing Custom Adapters
 

--- a/docs/ACP_GUIDE.md
+++ b/docs/ACP_GUIDE.md
@@ -416,8 +416,9 @@ Handlers can also implement `handle_session_update/4` and
 `handle_permission_request/5`. These optional variants receive the decoded
 JSON-RPC message that reached the ACP client, immediately before the handler
 state argument. When a variant is present, ExMCP calls it instead of the
-corresponding legacy callback. Keep the legacy callbacks to support older
-ExMCP versions.
+corresponding legacy callback. Both arities are optional, but a handler must
+implement at least one of each pair or the client refuses to start it. Keep the
+legacy callbacks as well if the handler must run on older ExMCP versions.
 
 The message retains unknown top-level and parameter fields and the permission
 request ID from the received ACP message. It is a decoded map, not the original

--- a/lib/ex_mcp/acp/adapter.ex
+++ b/lib/ex_mcp/acp/adapter.ex
@@ -15,6 +15,7 @@ defmodule ExMCP.ACP.Adapter do
 
   ## Optional Callbacks
 
+  - `name/0` — short adapter identifier used in `_meta.ex_mcp` namespaces
   - `capabilities/0` — return static agent capabilities
   - `post_connect/1` — called after Port is opened
   - `handle_adapter_message/2` — handle process messages for adapter-managed subprocesses
@@ -203,7 +204,18 @@ defmodule ExMCP.ACP.Adapter do
   @callback fork_session(params :: map(), state()) ::
               {:ok, map(), state()} | {:error, any(), state()}
 
+  @doc """
+  Short identifier for the adapter, such as `"claude_sdk"` or `"codex"`.
+
+  `AdapterBridge` reports it as `_meta.ex_mcp.native.adapter` on every ACP
+  message derived from a native line, and adapters use it as the key for their
+  own extension data under `_meta.ex_mcp`. When not implemented, the bridge
+  derives it from the module's last name segment in lower case.
+  """
+  @callback name() :: String.t()
+
   @optional_callbacks [
+    name: 0,
     capabilities: 0,
     post_connect: 1,
     env: 1,

--- a/lib/ex_mcp/acp/adapter_bridge.ex
+++ b/lib/ex_mcp/acp/adapter_bridge.ex
@@ -29,7 +29,7 @@ defmodule ExMCP.ACP.AdapterBridge do
   use GenServer
 
   alias ExMCP.ACP.AdapterBridge.PortRunner
-  alias ExMCP.ACP.{Capabilities, Envelope}
+  alias ExMCP.ACP.{Capabilities, Envelope, Meta}
   alias ExMCP.Internal.{Maps, Options}
 
   @type t :: GenServer.server()
@@ -55,6 +55,9 @@ defmodule ExMCP.ACP.AdapterBridge do
     one_shot_tasks: %{},
     one_shot_monitors: %{},
     buffer: "",
+    native_events: :summary,
+    native_sequence: 0,
+    adapter_name: nil,
     status: :connecting
   ]
 
@@ -100,6 +103,8 @@ defmodule ExMCP.ACP.AdapterBridge do
       adapter_mod: adapter_mod,
       adapter_state: adapter_state,
       adapter_opts: adapter_opts,
+      adapter_name: adapter_name(adapter_mod),
+      native_events: native_events_option(opts),
       outbox: :queue.new(),
       waiters: :queue.new(),
       max_buffer_bytes:
@@ -419,11 +424,17 @@ defmodule ExMCP.ACP.AdapterBridge do
     end
   end
 
+  # The adapter's own `name/0` when it has one; otherwise the module's last
+  # segment in lower case. Used for agentInfo.name and `_meta.ex_mcp.native`.
   defp adapter_name(mod) do
-    mod
-    |> Module.split()
-    |> List.last()
-    |> String.downcase()
+    if function_exported?(mod, :name, 0) do
+      mod.name()
+    else
+      mod
+      |> Module.split()
+      |> List.last()
+      |> String.downcase()
+    end
   end
 
   # Synthesize responses for ACP methods that adapted agents don't handle natively.
@@ -1075,11 +1086,11 @@ defmodule ExMCP.ACP.AdapterBridge do
     case state.adapter_mod.translate_inbound(line, state.adapter_state) do
       {:messages, messages, new_adapter_state} ->
         state = %{state | adapter_state: new_adapter_state}
-        push_messages(state, Enum.map(messages, &Jason.encode!/1))
+        push_native_messages(state, messages, line)
 
       {:messages_and_write, messages, write_data, new_adapter_state} ->
         state = %{state | adapter_state: new_adapter_state}
-        state = push_messages(state, Enum.map(messages, &Jason.encode!/1))
+        state = push_native_messages(state, messages, line)
         _ = write_to_port(state, write_data)
         state
 
@@ -1104,10 +1115,70 @@ defmodule ExMCP.ACP.AdapterBridge do
     case state.adapter_mod.translate_inbound(buffer, state.adapter_state) do
       {:messages, messages, new_adapter_state} ->
         state = %{state | adapter_state: new_adapter_state}
-        push_messages(state, Enum.map(messages, &Jason.encode!/1))
+        push_native_messages(state, messages, buffer)
 
       _ ->
         state
+    end
+  end
+
+  # Every ACP message an adapter derives from one native line is tagged under
+  # `_meta.ex_mcp.native` with the adapter name and a per-bridge sequence
+  # number, plus the decoded native event when `native_events: :raw` is set.
+  # Messages the adapter produces outside `translate_inbound/2` (post_connect,
+  # adapter-managed processes, synthesized responses) are not derived from a
+  # native line and are left untouched.
+  defp push_native_messages(state, [], _line), do: state
+
+  defp push_native_messages(%{native_events: :off} = state, messages, _line),
+    do: push_messages(state, Enum.map(messages, &Jason.encode!/1))
+
+  defp push_native_messages(state, messages, line) do
+    sequence = state.native_sequence + 1
+
+    native =
+      %{"adapter" => state.adapter_name, "sequence" => sequence}
+      |> maybe_put_native_event(state.native_events, line)
+
+    encoded = Enum.map(messages, &(&1 |> put_native_meta(native) |> Jason.encode!()))
+    push_messages(%{state | native_sequence: sequence}, encoded)
+  end
+
+  defp maybe_put_native_event(native, :raw, line) do
+    case Jason.decode(line) do
+      {:ok, event} -> Map.put(native, "event", event)
+      {:error, _} -> Map.put(native, "raw", line)
+    end
+  end
+
+  defp maybe_put_native_event(native, _mode, _line), do: native
+
+  defp put_native_meta(
+         %{"method" => "session/update", "params" => %{"update" => update} = params} = message,
+         native
+       )
+       when is_map(update) do
+    update = Meta.put_ex_mcp(update, %{"native" => native})
+    %{message | "params" => %{params | "update" => update}}
+  end
+
+  defp put_native_meta(%{"method" => _, "params" => params} = message, native)
+       when is_map(params),
+       do: %{message | "params" => Meta.put_ex_mcp(params, %{"native" => native})}
+
+  defp put_native_meta(%{"result" => result} = message, native) when is_map(result),
+    do: %{message | "result" => Meta.put_ex_mcp(result, %{"native" => native})}
+
+  defp put_native_meta(message, _native), do: message
+
+  defp native_events_option(opts) do
+    case Keyword.get(opts, :native_events, :summary) do
+      mode when mode in [:off, :summary, :raw] ->
+        mode
+
+      other ->
+        raise ArgumentError,
+              "native_events must be :off, :summary, or :raw, got: #{inspect(other)}"
     end
   end
 

--- a/lib/ex_mcp/acp/adapter_transport.ex
+++ b/lib/ex_mcp/acp/adapter_transport.ex
@@ -13,6 +13,22 @@ defmodule ExMCP.ACP.AdapterTransport do
 
   The transport starts an `AdapterBridge` on connect, which in turn launches
   the agent subprocess and handles protocol translation.
+
+  ## Native event metadata
+
+  Every ACP message the adapter derives from a native agent line carries
+  `_meta.ex_mcp.native` with the adapter `name` and a per-connection
+  `sequence` number. The `:native_events` option controls how much is kept:
+
+    * `:summary` (default) - adapter name and sequence only
+    * `:raw` - also embeds the decoded native event under `event` (or the
+      unparsed line under `raw`); this can make updates much larger and the
+      retained data counts toward the client's `:max_update_queue_bytes`
+    * `:off` - no native block
+
+  For `session/update` the block sits on the update's `_meta`; for other
+  agent-to-client requests it sits on `params._meta`; for responses on
+  `result._meta`.
   """
 
   @behaviour ExMCP.Transport
@@ -34,7 +50,8 @@ defmodule ExMCP.ACP.AdapterTransport do
           :max_outbox_messages,
           :max_outbox_bytes,
           :max_waiters,
-          :max_one_shot_tasks
+          :max_one_shot_tasks,
+          :native_events
         ])
 
     case AdapterBridge.start_link(bridge_opts) do

--- a/lib/ex_mcp/acp/adapters/claude_sdk.ex
+++ b/lib/ex_mcp/acp/adapters/claude_sdk.ex
@@ -9,6 +9,9 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK do
 
   @behaviour ExMCP.ACP.Adapter
 
+  @impl true
+  def name, do: "claude_sdk"
+
   require Logger
 
   alias ExMCP.ACP.Adapters.ClaudeSDK.Mapper
@@ -116,9 +119,11 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK do
         "additionalDirectories" => %{}
       },
       "_meta" => %{
-        "ex_mcp.claude_sdk" => %{
-          "streaming" => true,
-          "controlProtocol" => true
+        "ex_mcp" => %{
+          "claude_sdk" => %{
+            "streaming" => true,
+            "controlProtocol" => true
+          }
         }
       }
     }

--- a/lib/ex_mcp/acp/adapters/claude_sdk/mapper.ex
+++ b/lib/ex_mcp/acp/adapters/claude_sdk/mapper.ex
@@ -171,10 +171,12 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
         "toolCallId" => event["tool_use_id"],
         "status" => "in_progress",
         "_meta" => %{
-          "ex_mcp.claude_sdk" => %{
-            "toolName" => event["tool_name"],
-            "elapsedTimeSeconds" => event["elapsed_time_seconds"],
-            "taskId" => event["task_id"]
+          "ex_mcp" => %{
+            "claude_sdk" => %{
+              "toolName" => event["tool_name"],
+              "elapsedTimeSeconds" => event["elapsed_time_seconds"],
+              "taskId" => event["task_id"]
+            }
           }
         }
       }
@@ -184,7 +186,9 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
   end
 
   def reduce_message(%{"type" => "tool_use_summary"} = event, state) do
-    update = %{"_meta" => %{"ex_mcp.claude_sdk" => %{"toolUseSummary" => event["summary"]}}}
+    update = %{
+      "_meta" => %{"ex_mcp" => %{"claude_sdk" => %{"toolUseSummary" => event["summary"]}}}
+    }
 
     {[AdapterEvents.session_info_update(session_id(state), update)], [], state}
   end
@@ -192,9 +196,11 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
   def reduce_message(%{"type" => "rate_limit_event"} = event, state) do
     update = %{
       "_meta" => %{
-        "ex_mcp.claude_sdk" => %{
-          "status" => "rate_limited",
-          "rateLimitInfo" => event["rate_limit_info"]
+        "ex_mcp" => %{
+          "claude_sdk" => %{
+            "status" => "rate_limited",
+            "rateLimitInfo" => event["rate_limit_info"]
+          }
         }
       }
     }
@@ -321,14 +327,16 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
 
   defp replay_meta(event) do
     %{
-      "ex_mcp.claude_sdk" =>
-        %{
-          "replay" => true,
-          "messageUuid" => message_uuid(event),
-          "parentUuid" => event["parentUuid"] || event["parent_uuid"],
-          "timestamp" => event["timestamp"]
-        }
-        |> compact()
+      "ex_mcp" => %{
+        "claude_sdk" =>
+          %{
+            "replay" => true,
+            "messageUuid" => message_uuid(event),
+            "parentUuid" => event["parentUuid"] || event["parent_uuid"],
+            "timestamp" => event["timestamp"]
+          }
+          |> compact()
+      }
     }
   end
 
@@ -798,7 +806,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
         usage_update(acp_session_id, usage, result, state),
         config_option_update(state),
         AdapterEvents.session_info_update(acp_session_id, %{
-          "_meta" => %{"ex_mcp.claude_sdk" => %{"status" => "waiting_for_subagents"}}
+          "_meta" => %{"ex_mcp" => %{"claude_sdk" => %{"status" => "waiting_for_subagents"}}}
         }),
         result_text_chunk(acp_session_id, text, state)
       ]
@@ -834,15 +842,17 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
         "stopReason" => stop_reason(result),
         "usage" => usage,
         "_meta" => %{
-          "ex_mcp.claude_sdk" =>
-            %{
-              "text" => text,
-              "sessionId" => claude_session_id,
-              "modelUsage" => result["modelUsage"],
-              "totalCostUsd" => result["total_cost_usd"],
-              "errors" => result["errors"]
-            }
-            |> compact()
+          "ex_mcp" => %{
+            "claude_sdk" =>
+              %{
+                "text" => text,
+                "sessionId" => claude_session_id,
+                "modelUsage" => result["modelUsage"],
+                "totalCostUsd" => result["total_cost_usd"],
+                "errors" => result["errors"]
+              }
+              |> compact()
+          }
         }
       }
       |> maybe_put_error_meta(result)
@@ -852,7 +862,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
         usage_update(acp_session_id, usage, result, state),
         config_option_update(state),
         AdapterEvents.session_info_update(acp_session_id, %{
-          "_meta" => %{"ex_mcp.claude_sdk" => %{"status" => "completed"}}
+          "_meta" => %{"ex_mcp" => %{"claude_sdk" => %{"status" => "completed"}}}
         }),
         result_text_chunk(acp_session_id, text, state)
       ]
@@ -907,16 +917,18 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
       [
         AdapterEvents.session_info_update(session_id(state), %{
           "_meta" => %{
-            "ex_mcp.claude_sdk" =>
-              %{
-                "status" => "initialized",
-                "sessionId" => state.claude_session_id,
-                "claudeCodeVersion" => event["claude_code_version"],
-                "cwd" => event["cwd"],
-                "tools" => event["tools"],
-                "mcpServers" => event["mcp_servers"]
-              }
-              |> compact()
+            "ex_mcp" => %{
+              "claude_sdk" =>
+                %{
+                  "status" => "initialized",
+                  "sessionId" => state.claude_session_id,
+                  "claudeCodeVersion" => event["claude_code_version"],
+                  "cwd" => event["cwd"],
+                  "tools" => event["tools"],
+                  "mcpServers" => event["mcp_servers"]
+                }
+                |> compact()
+            }
           }
         }),
         current_mode_update(state),
@@ -934,13 +946,15 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
     update =
       %{
         "_meta" => %{
-          "ex_mcp.claude_sdk" =>
-            %{
-              "status" => event["status"],
-              "compactResult" => event["compact_result"],
-              "compactError" => event["compact_error"]
-            }
-            |> compact()
+          "ex_mcp" => %{
+            "claude_sdk" =>
+              %{
+                "status" => event["status"],
+                "compactResult" => event["compact_result"],
+                "compactError" => event["compact_error"]
+              }
+              |> compact()
+          }
         }
       }
 
@@ -952,7 +966,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
   end
 
   defp handle_system(%{"subtype" => "session_state_changed"} = event, state) do
-    update = %{"_meta" => %{"ex_mcp.claude_sdk" => %{"sessionState" => event["state"]}}}
+    update = %{"_meta" => %{"ex_mcp" => %{"claude_sdk" => %{"sessionState" => event["state"]}}}}
     info = AdapterEvents.session_info_update(session_id(state), update)
 
     if event["state"] == "idle" and not is_nil(state.deferred_result) and
@@ -989,13 +1003,15 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
         "status" => "failed",
         "rawOutput" => event["message"],
         "_meta" => %{
-          "ex_mcp.claude_sdk" =>
-            %{
-              "toolName" => event["tool_name"],
-              "decisionReason" => event["decision_reason"],
-              "decisionReasonType" => event["decision_reason_type"]
-            }
-            |> compact()
+          "ex_mcp" => %{
+            "claude_sdk" =>
+              %{
+                "toolName" => event["tool_name"],
+                "decisionReason" => event["decision_reason"],
+                "decisionReasonType" => event["decision_reason_type"]
+              }
+              |> compact()
+          }
         }
       }
 
@@ -1004,7 +1020,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
 
   defp handle_system(%{"subtype" => subtype} = event, state) do
     update = %{
-      "_meta" => %{"ex_mcp.claude_sdk" => %{"systemSubtype" => subtype, "event" => event}}
+      "_meta" => %{"ex_mcp" => %{"claude_sdk" => %{"systemSubtype" => subtype, "event" => event}}}
     }
 
     {[AdapterEvents.session_info_update(session_id(state), update)], [], state}
@@ -1067,7 +1083,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
           "exit_code" => exit_code,
           "signal" => nil
         },
-        "ex_mcp.claude_sdk" => %{"isError" => is_error}
+        "ex_mcp" => %{"claude_sdk" => %{"isError" => is_error}}
       }
     }
     |> compact()
@@ -1083,10 +1099,12 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
       "rawOutput" => parse_tool_result_raw(result["content"]),
       "_meta" =>
         %{
-          "ex_mcp.claude_sdk" => %{
-            "isError" => is_error,
-            "toolName" => tool[:name],
-            "toolInput" => tool[:input]
+          "ex_mcp" => %{
+            "claude_sdk" => %{
+              "isError" => is_error,
+              "toolName" => tool[:name],
+              "toolInput" => tool[:input]
+            }
           }
         }
         |> compact()
@@ -1557,11 +1575,11 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Mapper do
   end
 
   defp maybe_put_error_meta(response, %{"error" => error}) when error in @auth_errors do
-    put_in(response, ["_meta", "ex_mcp.claude_sdk", "authError"], error)
+    put_in(response, ["_meta", "ex_mcp", "claude_sdk", "authError"], error)
   end
 
   defp maybe_put_error_meta(response, %{"subtype" => subtype}) when is_binary(subtype) do
-    put_in(response, ["_meta", "ex_mcp.claude_sdk", "resultSubtype"], subtype)
+    put_in(response, ["_meta", "ex_mcp", "claude_sdk", "resultSubtype"], subtype)
   end
 
   defp maybe_put_error_meta(response, _result), do: response

--- a/lib/ex_mcp/acp/adapters/claude_sdk/protocol.ex
+++ b/lib/ex_mcp/acp/adapters/claude_sdk/protocol.ex
@@ -222,7 +222,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.Protocol do
             "optionId" => "allow_always",
             "name" => "Always allow",
             "kind" => "allow_always",
-            "_meta" => %{"ex_mcp.claude_sdk" => %{"updatedPermissions" => suggestions}}
+            "_meta" => %{"ex_mcp" => %{"claude_sdk" => %{"updatedPermissions" => suggestions}}}
           }
         ]
       end

--- a/lib/ex_mcp/acp/adapters/claude_sdk/session_store.ex
+++ b/lib/ex_mcp/acp/adapters/claude_sdk/session_store.ex
@@ -510,7 +510,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.SessionStore do
   defp maybe_put_meta(session, meta) when map_size(meta) == 0, do: session
 
   defp maybe_put_meta(session, meta),
-    do: Map.put(session, "_meta", %{"ex_mcp.claude_sdk" => meta})
+    do: Map.put(session, "_meta", %{"ex_mcp" => %{"claude_sdk" => meta}})
 
   defp sidechain?(head) do
     head

--- a/lib/ex_mcp/acp/adapters/claude_sdk/tool_info.ex
+++ b/lib/ex_mcp/acp/adapters/claude_sdk/tool_info.ex
@@ -125,7 +125,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.ToolInfo do
       "content" => [%{"type" => "terminal", "terminalId" => id}],
       "_meta" => %{
         "terminal_info" => %{"terminal_id" => id},
-        "ex_mcp.claude_sdk" => %{"terminal" => true, "command" => command}
+        "ex_mcp" => %{"claude_sdk" => %{"terminal" => true, "command" => command}}
       }
     }
   end

--- a/lib/ex_mcp/acp/adapters/codex.ex
+++ b/lib/ex_mcp/acp/adapters/codex.ex
@@ -17,6 +17,9 @@ defmodule ExMCP.ACP.Adapters.Codex do
 
   @behaviour ExMCP.ACP.Adapter
 
+  @impl true
+  def name, do: "codex"
+
   require Logger
 
   alias ExMCP.ACP.Adapters.Codex.{Config, Events, FileChanges, Protocol, Sessions, SlashCommands}
@@ -65,7 +68,7 @@ defmodule ExMCP.ACP.Adapters.Codex do
         "acp" => false,
         "http" => true,
         "sse" => false,
-        "_meta" => %{"ex_mcp.codex" => %{"stdioMcpServers" => true}}
+        "_meta" => %{"ex_mcp" => %{"codex" => %{"stdioMcpServers" => true}}}
       },
       "loadSession" => true,
       "auth" => %{"logout" => %{}},

--- a/lib/ex_mcp/acp/adapters/pi.ex
+++ b/lib/ex_mcp/acp/adapters/pi.ex
@@ -9,6 +9,9 @@ defmodule ExMCP.ACP.Adapters.Pi do
 
   @behaviour ExMCP.ACP.Adapter
 
+  @impl true
+  def name, do: "pi"
+
   require Logger
 
   alias ExMCP.ACP.AdapterBridge.PortRunner
@@ -96,18 +99,20 @@ defmodule ExMCP.ACP.Adapters.Pi do
         "embeddedContext" => System.get_env("PI_ACP_ENABLE_EMBEDDED_CONTEXT") == "true"
       },
       "_meta" => %{
-        "ex_mcp.pi" => %{
-          "sessionStore" => SessionStore.default_map_path(),
-          "thinkingLevels" => @thinking_levels,
-          "features" => %{
-            "slashCommands" => true,
-            "terminalAuth" => true,
-            "modelSelection" => true,
-            "sessionLoad" => true,
-            "sessionResume" => true,
-            "sessionClose" => true,
-            "sessionDelete" => true,
-            "structuredDiffs" => true
+        "ex_mcp" => %{
+          "pi" => %{
+            "sessionStore" => SessionStore.default_map_path(),
+            "thinkingLevels" => @thinking_levels,
+            "features" => %{
+              "slashCommands" => true,
+              "terminalAuth" => true,
+              "modelSelection" => true,
+              "sessionLoad" => true,
+              "sessionResume" => true,
+              "sessionClose" => true,
+              "sessionDelete" => true,
+              "structuredDiffs" => true
+            }
           }
         }
       }

--- a/lib/ex_mcp/acp/adapters/zcode.ex
+++ b/lib/ex_mcp/acp/adapters/zcode.ex
@@ -17,6 +17,9 @@ defmodule ExMCP.ACP.Adapters.ZCode do
 
   @behaviour ExMCP.ACP.Adapter
 
+  @impl true
+  def name, do: "zcode"
+
   require Logger
 
   alias ExMCP.ACP.Adapters.ZCode.{Config, Mapper, Protocol, Sessions}
@@ -80,7 +83,7 @@ defmodule ExMCP.ACP.Adapters.ZCode do
         "acp" => false,
         "http" => true,
         "sse" => true,
-        "_meta" => %{"ex_mcp.zcode" => %{"stdioMcpServers" => true}}
+        "_meta" => %{"ex_mcp" => %{"zcode" => %{"stdioMcpServers" => true}}}
       },
       "sessionCapabilities" => %{
         "list" => %{},
@@ -90,9 +93,11 @@ defmodule ExMCP.ACP.Adapters.ZCode do
         "fork" => %{}
       },
       "_meta" => %{
-        "ex_mcp.zcode" => %{
-          "streaming" => true,
-          "serverRequests" => true
+        "ex_mcp" => %{
+          "zcode" => %{
+            "streaming" => true,
+            "serverRequests" => true
+          }
         }
       }
     }

--- a/lib/ex_mcp/acp/client/handler.ex
+++ b/lib/ex_mcp/acp/client/handler.ex
@@ -7,6 +7,16 @@ defmodule ExMCP.ACP.Client.Handler do
   from ACP agents.
 
   See `ExMCP.ACP.Client.DefaultHandler` for a reference implementation.
+
+  Session updates and permission requests each have a legacy callback and a
+  context-aware variant that also receives the decoded JSON-RPC message
+  (`c:handle_session_update/3` or `c:handle_session_update/4`, and
+  `c:handle_permission_request/4` or `c:handle_permission_request/5`). Both
+  arities are optional so a handler can implement only the variant it needs,
+  but it must implement at least one of each pair: the client refuses to start
+  a handler that implements neither, with
+  `{:handler_init_failed, {:missing_callback, name}}`. When both are present
+  the context-aware variant is called.
   """
 
   @type state :: any()
@@ -19,6 +29,8 @@ defmodule ExMCP.ACP.Client.Handler do
 
   The `update` map contains a `"sessionUpdate"` discriminator field indicating
   the update type (e.g., `"agent_message_chunk"`, `"tool_call"`, `"plan"`, etc.).
+
+  Optional when `c:handle_session_update/4` is implemented.
   """
   @callback handle_session_update(session_id :: String.t(), update :: map(), state()) ::
               {:ok, state()}
@@ -131,7 +143,9 @@ defmodule ExMCP.ACP.Client.Handler do
   @callback terminate(reason :: any(), state()) :: :ok
 
   @optional_callbacks [
+    handle_session_update: 3,
     handle_session_update: 4,
+    handle_permission_request: 4,
     handle_permission_request: 5,
     handle_file_read: 4,
     handle_file_write: 4,

--- a/lib/ex_mcp/acp/client/handler_runner.ex
+++ b/lib/ex_mcp/acp/client/handler_runner.ex
@@ -98,10 +98,23 @@ defmodule ExMCP.ACP.Client.HandlerRunner do
     GenServer.cast(pid, {:elicitation_complete, elicitation_id})
   end
 
+  # Each of these has a legacy arity and a context-aware arity that also takes
+  # the decoded JSON-RPC message. Both are optional on the behaviour so a
+  # handler can implement just one, but it must export at least one of each
+  # or updates and permission requests would fail at first dispatch.
+  @callback_pairs [handle_session_update: [3, 4], handle_permission_request: [4, 5]]
+
   @impl true
   def init({handler_mod, handler_opts, owner}) do
     Process.flag(:trap_exit, true)
 
+    case missing_callback(handler_mod) do
+      nil -> init_handler(handler_mod, handler_opts, owner)
+      callback -> {:stop, {:handler_init_failed, {:missing_callback, callback}}}
+    end
+  end
+
+  defp init_handler(handler_mod, handler_opts, owner) do
     case safe_call(fn -> handler_mod.init(handler_opts) end) do
       {:ok, {:ok, handler_state}} ->
         {:ok, %__MODULE__{handler_mod: handler_mod, handler_state: handler_state, owner: owner}}
@@ -115,6 +128,14 @@ defmodule ExMCP.ACP.Client.HandlerRunner do
       {:error, reason} ->
         {:stop, {:handler_init_failed, reason}}
     end
+  end
+
+  defp missing_callback(handler_mod) do
+    Code.ensure_loaded(handler_mod)
+
+    Enum.find_value(@callback_pairs, fn {callback, arities} ->
+      if not Enum.any?(arities, &function_exported?(handler_mod, callback, &1)), do: callback
+    end)
   end
 
   @impl true

--- a/test/ex_mcp/acp/adapter_bridge_test.exs
+++ b/test/ex_mcp/acp/adapter_bridge_test.exs
@@ -505,6 +505,76 @@ defmodule ExMCP.ACP.AdapterBridgeTest do
     end
   end
 
+  describe "native event metadata" do
+    test "summary mode tags adapter name and sequence on every derived message" do
+      {:ok, bridge} = AdapterBridge.start_link(adapter: MockAdapter, adapter_opts: [])
+      _init = send_initialize(bridge)
+
+      assert prompt_and_native(bridge, "one") == %{"adapter" => "mockadapter", "sequence" => 1}
+      assert prompt_and_native(bridge, "two") == %{"adapter" => "mockadapter", "sequence" => 2}
+
+      AdapterBridge.close(bridge)
+    end
+
+    test "raw mode also embeds the decoded native event" do
+      {:ok, bridge} =
+        AdapterBridge.start_link(adapter: MockAdapter, adapter_opts: [], native_events: :raw)
+
+      _init = send_initialize(bridge)
+
+      assert prompt_and_native(bridge, "raw") == %{
+               "adapter" => "mockadapter",
+               "sequence" => 1,
+               "event" => %{"type" => "echo", "text" => "raw"}
+             }
+
+      AdapterBridge.close(bridge)
+    end
+
+    test "off mode leaves adapter messages untouched" do
+      {:ok, bridge} =
+        AdapterBridge.start_link(adapter: MockAdapter, adapter_opts: [], native_events: :off)
+
+      _init = send_initialize(bridge)
+
+      assert prompt_and_native(bridge, "off") == nil
+
+      AdapterBridge.close(bridge)
+    end
+
+    test "rejects an unknown native_events mode" do
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {%ArgumentError{}, _stack}} =
+               AdapterBridge.start_link(
+                 adapter: MockAdapter,
+                 adapter_opts: [],
+                 native_events: :verbose
+               )
+    end
+  end
+
+  defp prompt_and_native(bridge, text) do
+    prompt = %{
+      "jsonrpc" => "2.0",
+      "id" => System.unique_integer([:positive]),
+      "method" => "session/prompt",
+      "params" => %{
+        "sessionId" => "test_session",
+        "prompt" => [%{"type" => "text", "text" => text}]
+      }
+    }
+
+    assert :ok = AdapterBridge.send_message(bridge, Jason.encode!(prompt))
+    assert {:ok, raw} = AdapterBridge.receive_message(bridge, 5_000)
+    msg = Jason.decode!(raw)
+
+    assert msg["method"] == "session/update"
+    assert msg["params"]["update"]["content"] == %{"type" => "text", "text" => text}
+
+    get_in(msg, ["params", "update", "_meta", "ex_mcp", "native"])
+  end
+
   describe "one-shot adapter" do
     test "produces results without persistent Port" do
       {:ok, bridge} = AdapterBridge.start_link(adapter: OneShotMockAdapter, adapter_opts: [])

--- a/test/ex_mcp/acp/adapters/claude_sdk/session_store_test.exs
+++ b/test/ex_mcp/acp/adapters/claude_sdk/session_store_test.exs
@@ -62,9 +62,9 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDK.SessionStoreTest do
       assert session["cwd"] == cwd
       assert session["title"] == "Summary Title"
       assert session["updatedAt"] =~ "T"
-      assert get_in(session, ["_meta", "ex_mcp.claude_sdk", "fileSize"]) > 0
-      assert get_in(session, ["_meta", "ex_mcp.claude_sdk", "firstPrompt"]) == "first prompt"
-      assert get_in(session, ["_meta", "ex_mcp.claude_sdk", "gitBranch"]) == "feature/acp"
+      assert get_in(session, ["_meta", "ex_mcp", "claude_sdk", "fileSize"]) > 0
+      assert get_in(session, ["_meta", "ex_mcp", "claude_sdk", "firstPrompt"]) == "first prompt"
+      assert get_in(session, ["_meta", "ex_mcp", "claude_sdk", "gitBranch"]) == "feature/acp"
     end
 
     test "filters sidechains, invalid names, empty files, and untitled sessions", %{

--- a/test/ex_mcp/acp/adapters/claude_sdk_test.exs
+++ b/test/ex_mcp/acp/adapters/claude_sdk_test.exs
@@ -494,7 +494,8 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDKTest do
                "params",
                "update",
                "_meta",
-               "ex_mcp.claude_sdk",
+               "ex_mcp",
+               "claude_sdk",
                "sessionId"
              ]) == cli_uuid
 
@@ -533,7 +534,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDKTest do
       assert_update_session_ids(result_messages, acp_id)
       response = Enum.find(result_messages, &(&1["id"] == 8))
 
-      assert get_in(response, ["result", "_meta", "ex_mcp.claude_sdk", "sessionId"]) ==
+      assert get_in(response, ["result", "_meta", "ex_mcp", "claude_sdk", "sessionId"]) ==
                cli_uuid
 
       assert state.session_id == acp_id
@@ -826,7 +827,9 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDKTest do
 
       assert response["result"]["stopReason"] == "max_tokens"
       assert response["result"]["usage"]["inputTokens"] == 1
-      assert get_in(response, ["result", "_meta", "ex_mcp.claude_sdk", "text"]) == "hello world"
+
+      assert get_in(response, ["result", "_meta", "ex_mcp", "claude_sdk", "text"]) ==
+               "hello world"
 
       refute Enum.any?(
                messages,
@@ -864,7 +867,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDKTest do
       assert get_in(chunk, ["params", "update", "content", "text"]) == "final only answer"
       assert response["result"]["stopReason"] == "end_turn"
 
-      assert get_in(response, ["result", "_meta", "ex_mcp.claude_sdk", "text"]) ==
+      assert get_in(response, ["result", "_meta", "ex_mcp", "claude_sdk", "text"]) ==
                "final only answer"
 
       assert state.pending_prompt_id == nil
@@ -1153,7 +1156,7 @@ defmodule ExMCP.ACP.Adapters.ClaudeSDKTest do
       response = Enum.find(messages, &(&1["id"] == 321))
       assert response["result"]["stopReason"] == "end_turn"
 
-      assert get_in(response, ["result", "_meta", "ex_mcp.claude_sdk", "sessionId"]) ==
+      assert get_in(response, ["result", "_meta", "ex_mcp", "claude_sdk", "sessionId"]) ==
                cli_uuid
 
       assert_update_session_ids(messages, acp_id)

--- a/test/ex_mcp/acp/adapters/pi_test.exs
+++ b/test/ex_mcp/acp/adapters/pi_test.exs
@@ -116,7 +116,7 @@ defmodule ExMCP.ACP.Adapters.PiTest do
   describe "capabilities/0" do
     test "returns ACP-native capabilities and adapter metadata" do
       caps = Pi.capabilities()
-      pi_meta = caps["_meta"]["ex_mcp.pi"]
+      pi_meta = caps["_meta"]["ex_mcp"]["pi"]
 
       assert caps["loadSession"] == true
       assert caps["promptCapabilities"]["image"] == true

--- a/test/ex_mcp/acp/client_message_context_test.exs
+++ b/test/ex_mcp/acp/client_message_context_test.exs
@@ -40,6 +40,54 @@ defmodule ExMCP.ACP.ClientMessageContextTest do
     end
   end
 
+  defmodule ContextOnlyHandler do
+    @behaviour ExMCP.ACP.Client.Handler
+
+    @impl true
+    def init(opts), do: {:ok, %{parent: Keyword.fetch!(opts, :parent)}}
+
+    @impl true
+    def handle_session_update(session_id, update, message, state) do
+      send(state.parent, {:context_only_update, session_id, update, message})
+      {:ok, state}
+    end
+
+    @impl true
+    def handle_permission_request(_session_id, _tool_call, _options, message, state) do
+      send(state.parent, {:context_only_permission, message})
+      {:ok, %{"outcome" => "selected", "optionId" => "allow"}, state}
+    end
+  end
+
+  defmodule NoCallbacksHandler do
+    @behaviour ExMCP.ACP.Client.Handler
+
+    @impl true
+    def init(_opts), do: {:ok, %{}}
+  end
+
+  test "handlers may implement only the context-aware callbacks" do
+    {client, transport} = start_client(handler: ContextOnlyHandler)
+    update = update_message("context only")
+
+    send(client, {:transport_message, update})
+    assert_receive {:context_only_update, "context-session", _, ^update}
+
+    request = permission_message("context-only")
+    send_raw(transport, request)
+    assert_receive {:context_only_permission, ^request}
+
+    assert %{"id" => "context-only", "result" => %{"outcome" => %{"outcome" => "selected"}}} =
+             receive_raw(transport)
+  end
+
+  test "a handler missing both arities of a callback pair does not start" do
+    Process.flag(:trap_exit, true)
+
+    assert {:error, {:handler_init_failed, {:missing_callback, :handle_session_update}}} =
+             ExMCP.ACP.Client.HandlerRunner.start_link(NoCallbacksHandler, [], self())
+  end
+
   test "preserves complete decoded messages and callback ordering without changing event listeners" do
     {client, _transport} = start_client(event_listener: self())
     first = update_message("first")


### PR DESCRIPTION
Follow-up to #32 / #34 for the 1.3.0 release. Jido Harness will consume whatever shape we define, so this settles the `_meta` namespace, adds the opt-in raw native event, and makes the legacy handler callbacks optional.

## Namespace: one nested `_meta.ex_mcp` map

Adapters attached extension data in three shapes: a flat `"ex_mcp.claude_sdk"` key (Claude SDK, everywhere), flat `"ex_mcp.codex"` / `"ex_mcp.pi"` / `"ex_mcp.zcode"` keys on capability advertisements, and the nested `_meta.ex_mcp.<adapter>` map that the ACP guide, the 1.0 CHANGELOG, and Codex/Pi updates already used. Everything now uses the nested form. The documented dotted paths such as `_meta.ex_mcp.claude_sdk.sessionId` are unchanged and now match the wire.

**BREAKING for consumers reading the flat keys**: read `_meta["ex_mcp"]["claude_sdk"]` (etc.) instead. Marked as such in the CHANGELOG under Unreleased.

## Provenance: `_meta.ex_mcp.native`

`AdapterBridge` tags every ACP message an adapter derives from one native line:

| `native_events` | Contents of `_meta.ex_mcp.native` |
|---|---|
| `:summary` (default) | `adapter` name, per-connection `sequence` |
| `:raw` | plus the decoded native `event` (or unparsed `raw` line) |
| `:off` | block omitted |

All messages from the same native line share a `sequence`. `session/update` carries it on the update's `_meta`, other agent-to-client requests on `params._meta`, responses on `result._meta`. Messages an adapter produces outside `translate_inbound/2` (post_connect, adapter-managed processes, synthesized responses) are left alone. `AdapterTransport` forwards `:native_events`, so it can be passed straight to `ExMCP.ACP.Client.start_link/1`. Raw events count toward `:max_update_queue_bytes` like any retained update data (#32).

## `ExMCP.ACP.Adapter.name/0`

New optional callback. The bridge uses it for `agentInfo.name` and the native block, falling back to the lower-cased module segment as before. ClaudeSDK, Codex, Pi, and ZCode implement it (`"claude_sdk"`, `"codex"`, `"pi"`, `"zcode"`). Note `agentInfo.name` for ClaudeSDK changes from `"claudesdk"` to `"claude_sdk"`; nothing in the repo asserted the old value.

## Legacy handler callbacks are optional (second commit)

`handle_session_update/3` and `handle_permission_request/4` on `ExMCP.ACP.Client.Handler` were required, so a handler that only wants the context-aware `/4` and `/5` variants from #32 had to carry dead stubs. Both arities of each pair are now optional. `HandlerRunner` checks at init that the handler exports at least one arity of each pair and stops with `{:handler_init_failed, {:missing_callback, name}}` otherwise: louder than the compile-time warning it replaces, and it fails before the first update rather than at dispatch. Every existing handler already implements the legacy arities, so nothing changes for them.

## Docs

ACP guide: new "`_meta.ex_mcp` namespaces" section, a `:native_events` row in the client options table, a pointer from the message-context section, and the optional-callback rule. `AdapterTransport` and `Handler` moduledocs document the option and the rule.

## Validation (OTP 27.3.4 / Elixir 1.17.3)

- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix dialyzer`, `MIX_ENV=dev mix docs`: clean on both commits.
- `mix test test/ex_mcp/acp test/ex_mcp/security` under `env -i`: 667 tests, 5 doctests, 0 failures. New tests cover `:summary` sequencing, `:raw` embedding, `:off`, rejection of an unknown mode, a context-only handler end to end, and the missing-callback refusal.
- CI on the first commit (92b7829) passed all jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S1LGhfEJSxn1khq4mnG39