### PR TITLE
chore(acp): default native_events to :off and refresh planning docs for 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handler deadlines are unchanged. For adapted agents the message is the ACP envelope
   the adapter constructed, not the native provider event (#31, #32).
 
-- `_meta.ex_mcp.native` on every ACP message an adapter derives from a native agent
-  line: the adapter `name` and a per-connection `sequence`, plus the decoded native
-  `event` when `AdapterTransport`/`AdapterBridge` is started with `native_events: :raw`
-  (`:summary` is the default, `:off` disables the block). Adapters can implement the new
-  optional `ExMCP.ACP.Adapter.name/0` callback; the bridge derives a name from the module
-  otherwise.
+- Opt-in `_meta.ex_mcp.native` provenance on every ACP message an adapter derives from
+  a native agent line. Start `AdapterTransport`/`AdapterBridge` with
+  `native_events: :summary` for the adapter `name` and a per-connection `sequence`, or
+  `native_events: :raw` to also embed the decoded native `event`. The default is `:off`,
+  so existing consumers see no wire change. Adapters can implement the new optional
+  `ExMCP.ACP.Adapter.name/0` callback; the bridge derives a name from the module
+  otherwise, and Claude SDK's `agentInfo.name` is now `claude_sdk` instead of
+  `claudesdk`.
 
 ### Changed
 

--- a/docs/ACP_GUIDE.md
+++ b/docs/ACP_GUIDE.md
@@ -180,7 +180,7 @@ The adapter launches `zcode app-server`. Set `adapter_opts[:cli_path]` or the
 | `:handler_request_timeout` | `30_000` | Maximum lifetime for inbound handler callbacks |
 | `:max_update_queue` | `32` | Mailbox cutoff for handler and event-listener session updates; excess updates are dropped |
 | `:max_outbox_bytes` | `4_194_304` | Aggregate byte limit for an adapter bridge's undelivered messages |
-| `:native_events` | `:summary` | Adapter-bridged agents only: `_meta.ex_mcp.native` detail on derived messages (`:off`, `:summary`, or `:raw` to embed the decoded native event) |
+| `:native_events` | `:off` | Adapter-bridged agents only: opt-in `_meta.ex_mcp.native` provenance on derived messages (`:summary` for adapter name and sequence, `:raw` to also embed the decoded native event) |
 | `:name` | `nil` | GenServer name registration |
 
 ### Boolean Config Options
@@ -437,10 +437,10 @@ Both variants run through the existing handler runner. Retained update message
 data counts toward `:max_update_queue_bytes`, including fields outside the
 update. Legacy handlers and the event-listener message format are unchanged.
 
-For an adapted agent, the retained message already carries `_meta.ex_mcp.native`
-with the adapter name and sequence. Start the transport with
-`native_events: :raw` to also receive the decoded native provider event there;
-see "`_meta.ex_mcp` namespaces" below.
+For an adapted agent, start the transport with `native_events: :summary` to
+have the retained message carry `_meta.ex_mcp.native` with the adapter name and
+sequence, or `native_events: :raw` to also receive the decoded native provider
+event there; see "`_meta.ex_mcp` namespaces" below.
 
 ### Event Listener
 
@@ -490,16 +490,17 @@ implementations can ignore it as a unit:
 | Key | Set by | Contents |
 |-----|--------|----------|
 | `_meta.ex_mcp.<adapter>` | The adapter (`claude_sdk`, `codex`, `pi`, `zcode`) | Provider-specific fields the adapter chose to surface, such as Claude Code's session UUID, tool names, cost, or auth errors |
-| `_meta.ex_mcp.native` | `AdapterBridge` | Provenance of the ACP message: the adapter `name`, a per-connection `sequence` number, and with `native_events: :raw` the decoded native `event` |
+| `_meta.ex_mcp.native` | `AdapterBridge`, opt-in | Provenance of the ACP message: the adapter `name`, a per-connection `sequence` number, and with `native_events: :raw` the decoded native `event` |
 | `_meta.ex_mcp.mcpCapabilities.beam` | Capability negotiation | BEAM-local MCP transport support |
 
-The `native` block is attached to every ACP message an adapter derives from one
-native agent line, so all messages from the same line share a `sequence`. Pass
-`native_events: :raw` to `AdapterTransport` (or `AdapterBridge`) to embed the
-full native event, `:off` to drop the block entirely. Raw events can be large;
-they count toward the client's `:max_update_queue_bytes` like any other
-retained update data. Adapters implement `c:ExMCP.ACP.Adapter.name/0` to name
-their namespace; the bridge derives it from the module name otherwise.
+The `native` block is off by default. Pass `native_events: :summary` to
+`AdapterTransport` (or `AdapterBridge`) to attach it to every ACP message an
+adapter derives from one native agent line, so all messages from the same line
+share a `sequence`, or `native_events: :raw` to also embed the full native
+event. Raw events can be large; they count toward the client's
+`:max_update_queue_bytes` like any other retained update data. Adapters
+implement `c:ExMCP.ACP.Adapter.name/0` to name their namespace; the bridge
+derives it from the module name otherwise.
 
 ## Writing Custom Adapters
 

--- a/docs/POST_1_0_MAINTENANCE_PLAN.md
+++ b/docs/POST_1_0_MAINTENANCE_PLAN.md
@@ -6,7 +6,7 @@
 - **Baseline:** ExMCP `1.0.0`
 - **Scope:** behavior-preserving modularization, functional-core extraction,
   dependency cleanup, and Hex source-package cleanup
-- **Last updated:** 2026-09-02
+- **Last updated:** 2026-09-05
 
 This is a repository-maintenance document, not user-facing package
 documentation. It records cleanup that is valuable but too invasive to mix
@@ -232,11 +232,51 @@ noted:
 - **Ambient inputs:** open. The clock injection above is the first instance;
   remaining reads are handled case by case under the same 1.x rule.
 
+### Status as of 2026-09-05
+
+The 1.3.0 line adds ACP client and adapter work that was driven by a
+downstream consumer (Jido Harness) and is classified in
+[`V2_ROADMAP.md` section 8.2](./V2_ROADMAP.md#82-current-classifications):
+
+- **Handler message context:** `ExMCP.ACP.Client.Handler` gained optional
+  `handle_session_update/4` and `handle_permission_request/5` variants that
+  receive the decoded JSON-RPC message the client received. Both arities of
+  each pair are optional; `HandlerRunner` refuses to start a handler that
+  exports neither. Retained message data counts toward the handler update
+  queue byte limit.
+- **Adapter metadata namespace:** all adapter extension data lives under nested
+  `_meta.ex_mcp.<adapter>`, matching the documented shape. `AdapterBridge`
+  can tag adapter-derived messages with `_meta.ex_mcp.native` (adapter name,
+  per-connection sequence, optional decoded native event) behind the
+  `:native_events` option, which defaults to `:off` under the 1.x backport
+  rule. Adapters implement the optional `name/0` callback.
+- **Codex adapter correctness:** failed turns now fail the active prompt with
+  a classified error, and streamed agent text is tracked per item so neither
+  duplicate nor dropped messages reach chunk consumers. The second fix was
+  found by review on the first; the per-turn accumulator had silently become
+  ambiguous in a module that has grown to about 4,519 lines.
+- **Dependency security:** mint 1.10.0. The three Cowlib 2.19.0 exceptions in
+  `mix.exs` remain; no patched Cowlib had been published as of 2026-09-05 and
+  the 2026-09-12 review date stands.
+
+Related maintenance figures at this baseline: `ExMCP.ACP.Adapters.Codex` is
+about 4,519 lines and `ExMCP.ACP.Adapters.Pi` about 2,553, up from the rc.7
+figures quoted above, so the modularization sections below are more pressing,
+not less. The existing `Codex.Sessions` helper covers session lookup and
+update only; the lifecycle-transition boundary in the Codex plan remains.
+Dialyzer reports 27 unnecessary entries in `.dialyzer_ignore.exs` on the CI
+dialyzer version; prune them once verified against the full OTP/Elixir matrix.
+
 ## Dependency-direction cleanup
 
-At commit `4591af6`, `mix xref graph --format stats` reports eight dependency
-cycles. Break them through narrow dependency inversion rather than moving code
-between large modules:
+At commit `4591af6`, `mix xref graph --format stats` reported eight dependency
+cycles. Under Elixir 1.17.3 / OTP 27 the same command reports 22 cycles at both
+the `v1.2.0` tag and the 1.3.0 baseline, none of them touching `lib/ex_mcp/acp`;
+they sit in the transport, client, internal, and content modules. Treat 22 as
+the current baseline and record the toolchain with any future count, since the
+difference from the earlier figure is a measurement change rather than a
+regression. Break the cycles through narrow dependency inversion rather than
+moving code between large modules:
 
 - move concrete `get_transport/1` selection out of the `ExMCP.Transport`
   behaviour and into a registry or factory;
@@ -449,7 +489,12 @@ existing, disabled-by-default Codex legacy compatibility option.
 5. Extract the shared HTTP reducer and the smallest high-value functional cores
    behind characterization tests.
 6. Modularize Codex one characterized boundary at a time. `Codex.Protocol` is
-   extracted; `Sessions`, `Permissions`, `Content`, and `MCP` remain.
+   extracted and `Codex.Sessions` holds lookup/update helpers; the lifecycle
+   `Sessions` boundary, `Permissions`, `Content`, and `MCP` remain. The 1.3.0
+   failed-turn and per-item streamed-text logic is a natural seed for the
+   event-folding and prompt-flow cores. This is behavior-preserving internal
+   work: it lands on `master` behind golden tests and ships with the next
+   user-visible release rather than forcing a release of its own.
 7. Modularize Pi one characterized boundary at a time. `Pi.RPC` is extracted;
    `Sessions`, `Events`, `PromptFlow`, and `Config` remain.
 8. Reduce dependency cycles without changing public or lifecycle semantics.

--- a/docs/V2_ROADMAP.md
+++ b/docs/V2_ROADMAP.md
@@ -2,7 +2,7 @@
 
 - **Status:** Living roadmap — Phase 0 complete; Phase 1 contract design is next
 - **Target:** ExMCP `2.0.0`, after stable `1.0.0` and the supported 1.x line
-- **Last updated:** 2026-09-02
+- **Last updated:** 2026-09-05
 - **Related release work:** [`RELEASE_1_0_0.md`](./RELEASE_1_0_0.md),
   [`API_DIFF_RC5_TO_1_0.md`](./API_DIFF_RC5_TO_1_0.md),
   [`POST_1_0_MAINTENANCE_PLAN.md`](./POST_1_0_MAINTENANCE_PLAN.md),
@@ -416,6 +416,11 @@ another 1.x RC or document a patch-level correctness/security exception.
 | Circuit breaker monotonic clock injection | Released in `1.2.0` | Characterized correctness fix; timeout and telemetry behavior preserved. |
 | Explicit client protocol-version query replacing `$initial_call` | Released in `1.2.0` | Identical results for every supported client entry point. |
 | `HttpPlug` body fallback, mount-independent routing, and terminal halt | Released in `1.2.0` | Documented bug fixes with regression tests; no wire change. |
+| ACP client handler message-context callbacks | Released in `1.3.0` | Additive optional `handle_session_update/4` and `handle_permission_request/5`; validation, session authority, correlation, cancellation, and deadlines unchanged. The legacy arities became optional with an init-time guard so no existing handler changes behavior. |
+| `_meta.ex_mcp.<adapter>` namespace consolidation | Released in `1.3.0` | Wire-visible, accepted as a documented-shape fix: the guide described the nested form since 1.0 while the Claude SDK adapter and the Codex, Pi, and ZCode capability advertisements emitted flat `"ex_mcp.<adapter>"` keys. Called out as BREAKING for flat-key readers. |
+| `_meta.ex_mcp.native` provenance and `Adapter.name/0` | Released in `1.3.0` | Default `:off` per §8.1; `native_events: :summary` and `:raw` are opt-in. The one default wire change is Claude SDK `agentInfo.name` becoming `claude_sdk`. |
+| Codex failed-turn errors and per-item streamed text | Released in `1.3.0` | Documented bug fixes with regression tests. A failed `turn/completed` now answers the prompt with a classified JSON-RPC error instead of an empty success. |
+| mint 1.10.0 | Released in `1.3.0` | Dependency security fix for EEF-CVE-2026-82728 and EEF-CVE-2026-82729. |
 | Internal dispatch deduplication | Case by case | Backport only when golden tests prove identical wire, errors, ordering, and lifecycle. |
 | Richer DSL constraints | Hold for 2.0 | Additive, but expands the stable public language before its design is settled. |
 | Result facade and client lifecycle helpers | Hold for 2.0 | Technically additive, but would create parallel APIs and long-term support obligations. |

--- a/lib/ex_mcp/acp/adapter_bridge.ex
+++ b/lib/ex_mcp/acp/adapter_bridge.ex
@@ -55,7 +55,7 @@ defmodule ExMCP.ACP.AdapterBridge do
     one_shot_tasks: %{},
     one_shot_monitors: %{},
     buffer: "",
-    native_events: :summary,
+    native_events: :off,
     native_sequence: 0,
     adapter_name: nil,
     status: :connecting
@@ -1122,12 +1122,13 @@ defmodule ExMCP.ACP.AdapterBridge do
     end
   end
 
-  # Every ACP message an adapter derives from one native line is tagged under
-  # `_meta.ex_mcp.native` with the adapter name and a per-bridge sequence
-  # number, plus the decoded native event when `native_events: :raw` is set.
-  # Messages the adapter produces outside `translate_inbound/2` (post_connect,
-  # adapter-managed processes, synthesized responses) are not derived from a
-  # native line and are left untouched.
+  # With `native_events: :summary` or `:raw`, every ACP message an adapter
+  # derives from one native line is tagged under `_meta.ex_mcp.native` with the
+  # adapter name and a per-bridge sequence number, plus the decoded native
+  # event for `:raw`. The default is `:off` so the 1.x wire shape is unchanged
+  # unless a consumer opts in. Messages the adapter produces outside
+  # `translate_inbound/2` (post_connect, adapter-managed processes, synthesized
+  # responses) are not derived from a native line and are left untouched.
   defp push_native_messages(state, [], _line), do: state
 
   defp push_native_messages(%{native_events: :off} = state, messages, _line),
@@ -1172,7 +1173,7 @@ defmodule ExMCP.ACP.AdapterBridge do
   defp put_native_meta(message, _native), do: message
 
   defp native_events_option(opts) do
-    case Keyword.get(opts, :native_events, :summary) do
+    case Keyword.get(opts, :native_events, :off) do
       mode when mode in [:off, :summary, :raw] ->
         mode
 

--- a/lib/ex_mcp/acp/adapter_transport.ex
+++ b/lib/ex_mcp/acp/adapter_transport.ex
@@ -16,15 +16,15 @@ defmodule ExMCP.ACP.AdapterTransport do
 
   ## Native event metadata
 
-  Every ACP message the adapter derives from a native agent line carries
-  `_meta.ex_mcp.native` with the adapter `name` and a per-connection
-  `sequence` number. The `:native_events` option controls how much is kept:
+  With the `:native_events` option, every ACP message the adapter derives from
+  a native agent line carries `_meta.ex_mcp.native` with the adapter `name`
+  and a per-connection `sequence` number:
 
-    * `:summary` (default) - adapter name and sequence only
+    * `:off` (default) - no native block; the wire shape is unchanged
+    * `:summary` - adapter name and sequence only
     * `:raw` - also embeds the decoded native event under `event` (or the
       unparsed line under `raw`); this can make updates much larger and the
       retained data counts toward the client's `:max_update_queue_bytes`
-    * `:off` - no native block
 
   For `session/update` the block sits on the update's `_meta`; for other
   agent-to-client requests it sits on `params._meta`; for responses on

--- a/test/ex_mcp/acp/adapter_bridge_test.exs
+++ b/test/ex_mcp/acp/adapter_bridge_test.exs
@@ -507,7 +507,9 @@ defmodule ExMCP.ACP.AdapterBridgeTest do
 
   describe "native event metadata" do
     test "summary mode tags adapter name and sequence on every derived message" do
-      {:ok, bridge} = AdapterBridge.start_link(adapter: MockAdapter, adapter_opts: [])
+      {:ok, bridge} =
+        AdapterBridge.start_link(adapter: MockAdapter, adapter_opts: [], native_events: :summary)
+
       _init = send_initialize(bridge)
 
       assert prompt_and_native(bridge, "one") == %{"adapter" => "mockadapter", "sequence" => 1}
@@ -527,6 +529,15 @@ defmodule ExMCP.ACP.AdapterBridgeTest do
                "sequence" => 1,
                "event" => %{"type" => "echo", "text" => "raw"}
              }
+
+      AdapterBridge.close(bridge)
+    end
+
+    test "the default leaves adapter messages untouched" do
+      {:ok, bridge} = AdapterBridge.start_link(adapter: MockAdapter, adapter_opts: [])
+      _init = send_initialize(bridge)
+
+      assert prompt_and_native(bridge, "default") == nil
 
       AdapterBridge.close(bridge)
     end


### PR DESCRIPTION
Pre-release follow-up to #35 / #36.

## `native_events` defaults to `:off`

`V2_ROADMAP.md` §8.1 requires 1.x additions to be opt-in or default-off and the wire shape to stay unchanged except for documented fixes. The `_meta.ex_mcp.native` block from #35 defaulted to `:summary`, which put it on every adapter-derived message for every consumer. It now defaults to `:off`; `:summary` and `:raw` are explicit opt-ins. Bridge, transport moduledoc, ACP guide (options table, namespaces section, message-context pointer), CHANGELOG, and the bridge tests are updated; a new test pins the default.

## Planning-document refresh

Mirrors what the 1.2.0 release commit did for both documents.

- **`V2_ROADMAP.md` §8.2** gains "Released in 1.3.0" rows for the handler message-context callbacks (and the optional legacy arities), the `_meta.ex_mcp` namespace consolidation (classified as a documented-shape fix, still flagged BREAKING for flat-key readers), the native provenance block and `Adapter.name/0` (default `:off` per §8.1, with the `agentInfo.name` change noted), the Codex fixes, and the mint bump.
- **`POST_1_0_MAINTENANCE_PLAN.md`** gains a 2026-09-05 status section covering the same work, the current Codex (~4,519 lines) and Pi (~2,553) sizes, the Cowlib exception review date, and the dialyzer ignore-file debt (27 unnecessary entries). The dependency-cycle paragraph is corrected: the "eight cycles" figure is stale; Elixir 1.17.3 / OTP 27 reports 22 at both `v1.2.0` and master, none in ACP, so it is a measurement change rather than a regression. The Codex modularization step now notes `Codex.Sessions` exists as a lookup/update helper and that the work is behavior-preserving and ships with the next user-visible release rather than forcing one.

No version bump here; the release commit (bump to 1.3.0, dated CHANGELOG section) can layer on top.

## Validation (OTP 27.3.4 / Elixir 1.17.3)

- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix dialyzer`, `MIX_ENV=dev mix docs`: clean.
- `mix test test/ex_mcp/acp test/ex_mcp/security` under `env -i`: 675 tests, 5 doctests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S1LGhfEJSxn1khq4mnG39

---
_Generated by [Claude Code](https://claude.ai/code/session_017S1LGhfEJSxn1khq4mnG39)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default `:native_events` mode alters wire metadata for adapter consumers that relied on the previous implicit `:summary` behavior without setting the option.
> 
> **Overview**
> Aligns adapter-bridged ACP wire behavior with the 1.x opt-in rule: **`_meta.ex_mcp.native` is no longer attached by default**.
> 
> `AdapterBridge` and `AdapterTransport` now default `:native_events` to **`:off`** (was `:summary`). Consumers must pass **`native_events: :summary`** or **`:raw`** to get adapter name/sequence or embedded native events on derived messages. **CHANGELOG**, **ACP_GUIDE** (options table, namespaces, handler message-context notes), and bridge moduledocs describe the opt-in model; tests explicitly enable `:summary`/`:raw` and add coverage that the default leaves messages unchanged.
> 
> Planning docs are refreshed for the **1.3.0** baseline: **V2_ROADMAP** §8.2 lists released 1.3.0 items; **POST_1_0_MAINTENANCE_PLAN** adds a 2026-09-05 status section (handler context callbacks, metadata namespaces, Codex fixes, mint bump), corrects xref cycle counts (22 under Elixir 1.17.3 / OTP 27), and updates Codex modularization notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac2b890a36e39e63b27bd677905186f5948deed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->