### PR TITLE
release: 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-09-05
+
+- ACP client handlers can receive the decoded JSON-RPC message for session updates and
+  permission requests, adapter extension data lives under one nested `_meta.ex_mcp`
+  namespace with opt-in native-event provenance, the Codex adapter reports failed turns
+  and streams agent text once, and mint moves to 1.10.0 for two security advisories.
+  The `_meta` key change is wire-visible for consumers that read the old flat keys; see
+  Changed. The pending Claude and Codex parity decisions recorded in
+  `docs/POST_1_0_MAINTENANCE_PLAN.md` remain open and the reference pins are unchanged.
+
 ### Added
 
 - Optional `handle_session_update/4` and `handle_permission_request/5` callbacks on

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExMCP.MixProject do
   use Mix.Project
 
-  @version "1.2.0"
+  @version "1.3.0"
   @github_url "https://github.com/azmaveth/ex_mcp"
 
   def project do


### PR DESCRIPTION
Bump to 1.3.0 and date the CHANGELOG section, following the 1.2.0 release pattern. The planning documents were already refreshed for this line in #37.

## What ships in 1.3.0

- **ACP client handler message context** (#32): optional `handle_session_update/4` and `handle_permission_request/5` receive the decoded JSON-RPC message; the legacy arities are now optional too, with an init-time guard (#35).
- **One nested `_meta.ex_mcp` namespace** for adapter extension data, with opt-in `_meta.ex_mcp.native` provenance (`native_events: :summary | :raw`, default `:off`) and the optional `Adapter.name/0` callback (#35, #37). The flat-key removal is flagged BREAKING in the CHANGELOG for consumers that read `"ex_mcp.claude_sdk"` and friends; the documented dotted paths are unchanged.
- **Codex adapter fixes** (#36): failed turns fail the prompt with a classified JSON-RPC error, and agent text is streamed once per item.
- **mint 1.10.0** for EEF-CVE-2026-82728 and EEF-CVE-2026-82729 (#34).

The lead bullet in the CHANGELOG also notes that the Claude and Codex parity decisions recorded in the maintenance plan remain open and the reference pins are unchanged, as the 1.2.0 entry did.

## Diff

- `mix.exs`: `@version "1.2.0"` → `"1.3.0"`
- `CHANGELOG.md`: `## [1.3.0] - 2026-09-05` heading and lead summary under a fresh empty Unreleased section

## Validation (OTP 27.3.4 / Elixir 1.17.3)

`mix compile --warnings-as-errors`, `mix hex.build`, and the pre-commit hook's format, credo, and dialyzer checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S1LGhfEJSxn1khq4mnG39

---
_Generated by [Claude Code](https://claude.ai/code/session_017S1LGhfEJSxn1khq4mnG39)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only updates the Hex/package version and changelog; runtime behavior was introduced in earlier merged work.
> 
> **Overview**
> Cuts **ExMCP 1.3.0** by bumping `@version` in `mix.exs` from `1.2.0` to **`1.3.0`** and adding a dated **`## [1.3.0] - 2026-09-05`** section in `CHANGELOG.md`, with an empty **`[Unreleased]`** heading above it (same pattern as prior releases).
> 
> The new changelog lead summarizes what this line ships: optional ACP client handler callbacks that receive the decoded JSON-RPC message, **BREAKING** nested `_meta.ex_mcp` adapter metadata (replacing flat keys), opt-in native-event provenance, Codex failed-turn and duplicate-stream fixes, and **mint 1.10.0** for two security advisories. No library code changes appear in this diff—only version and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd6bf3db6ddde35a487c44d477eba7de001fe8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->