### PR TITLE
test: supervise the schema resolver test agent to end a teardown race

### DIFF
--- a/test/ex_mcp/content/schema_remote_resolver_test.exs
+++ b/test/ex_mcp/content/schema_remote_resolver_test.exs
@@ -364,12 +364,16 @@ defmodule ExMCP.Content.SchemaRemoteResolverTest do
     policy_overrides = Keyword.get(overrides, :policy, [])
     network_overrides = Keyword.drop(overrides, [:dns, :policy])
 
-    {:ok, agent} =
-      Agent.start_link(fn -> %{routes: routes, dns: dns, fetches: [], lookups: []} end)
-
-    on_exit(fn ->
-      if Process.alive?(agent), do: Agent.stop(agent)
-    end)
+    # Supervised by ExUnit so teardown is deterministic. A linked agent plus an
+    # on_exit stop raced: the agent could die with the test process between the
+    # alive check and Agent.stop/1, failing the test in teardown (seen in CI).
+    agent =
+      start_supervised!(
+        Supervisor.child_spec(
+          {Agent, fn -> %{routes: routes, dns: dns, fetches: [], lookups: []} end},
+          id: {:resolver_agent, make_ref()}
+        )
+      )
 
     dns_resolver = fn host, _timeout ->
       Agent.get_and_update(agent, fn state ->


### PR DESCRIPTION
Post-1.3.0 test hygiene; no library change.

## Why

The first CI attempt for the release commit (477c780) failed one test on OTP 27.0 / Elixir 1.18.4:

```
1) test fetch and graph limits bounds each response (ExMCP.Content.SchemaRemoteResolverTest)
   ** (exit) exited in: GenServer.stop(#PID<0.13314.0>, :normal, :infinity)
       ** (EXIT) no process: the process is not alive ...
   (ex_unit 1.18.4) lib/ex_unit/on_exit_handler.ex:136: ExUnit.OnExitHandler.exec_callback/1
```

`resolver_options/2` started its routing `Agent` with `start_link` and stopped it in `on_exit` behind a `Process.alive?` check. `on_exit` runs after the test process has exited, and the linked agent can die in the window between the check and `Agent.stop/1`, so the test failed in teardown. The re-run passed, which is the signature of this race rather than a product bug.

## Fix

Start the agent under the ExUnit test supervisor with a unique child id (some tests call the helper twice), so shutdown is deterministic and the `on_exit` goes away.

## Validation

`mix test test/ex_mcp/content/schema_remote_resolver_test.exs --include integration` five times in a row under `env -i`: 20 tests, 0 failures each run. Format, credo, and dialyzer pass via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S1LGhfEJSxn1khq4mnG39

---
_Generated by [Claude Code](https://claude.ai/code/session_017S1LGhfEJSxn1khq4mnG39)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test infrastructure only; no production code or runtime behavior is modified.
> 
> **Overview**
> Fixes flaky CI teardown in `SchemaRemoteResolverTest` by changing how the mock routing `Agent` in `resolver_options/2` is started and stopped.
> 
> Instead of a linked `Agent.start_link` plus `on_exit` that calls `Agent.stop/1` after `Process.alive?`, the agent is registered with **`start_supervised!`** under ExUnit (unique `{:resolver_agent, make_ref()}` id so helpers can run twice in one test). ExUnit owns shutdown, so the race where the agent dies between the alive check and stop no longer fails the suite in teardown.
> 
> **Test-only** — no library behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf661dbc5f063ffa87d3f5273ef2ecf12f65415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->