### PR TITLE
fix(stdio): write JSON-RPC frames as UTF-8 bytes regardless of locale

### DIFF
--- a/lib/ex_mcp/server/stdio_server.ex
+++ b/lib/ex_mcp/server/stdio_server.ex
@@ -89,6 +89,9 @@ defmodule ExMCP.Server.StdioServer do
     # CRITICAL: For STDIO transport, suppress ALL logging to avoid contaminating JSON stream
     # MCP STDIO protocol requires ONLY JSON-RPC messages on stdout
     configure_stdio_logging()
+    # JSON carries UTF-8 bytes. Set byte mode before either reader or writer
+    # starts so the VM locale cannot transcode incoming or outgoing frames.
+    :ok = :io.setopts(:standard_io, encoding: :latin1)
 
     module = Keyword.fetch!(opts, :module)
     {subscription_opts, owned_subscription_runtime} = ensure_subscription_runtime(opts)
@@ -443,7 +446,7 @@ defmodule ExMCP.Server.StdioServer do
   # Send a successful response
   defp send_response(response, _state) do
     json = Jason.encode!(response)
-    IO.puts(json)
+    IO.binwrite(:stdio, [json, "\n"])
   end
 
   # Send an error response
@@ -451,7 +454,7 @@ defmodule ExMCP.Server.StdioServer do
     response = JSONRPC.error(id, code, message)
 
     json = Jason.encode!(response)
-    IO.puts(json)
+    IO.binwrite(:stdio, [json, "\n"])
   end
 
   # Configure logging for STDIO transport to prevent stdout contamination
@@ -461,7 +464,7 @@ defmodule ExMCP.Server.StdioServer do
 
   # Read from stdin in a loop and send lines to the main process
   defp read_stdin_loop(server_pid) do
-    case IO.read(:stdio, :line) do
+    case IO.binread(:stdio, :line) do
       :eof ->
         send(server_pid, {:stdin_closed})
 

--- a/test/ex_mcp/server/stdio_server_unicode_test.exs
+++ b/test/ex_mcp/server/stdio_server_unicode_test.exs
@@ -1,0 +1,79 @@
+defmodule ExMCP.Server.StdioServerUnicodeTest do
+  use ExUnit.Case, async: false
+
+  @tag timeout: 60_000
+  test "cold C-locale stdio preserves UTF-8 bytes and stops on EOF" do
+    dir = Path.join(System.tmp_dir!(), "ex-mcp-stdio-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    script = Path.join(dir, "server.exs")
+    input = Path.join(dir, "input.jsonl")
+
+    File.write!(script, """
+    # Reproduce the release device mode; Elixir CLI can force Unicode even in C.
+    :ok = :io.setopts(:standard_io, encoding: :latin1)
+    defmodule EchoServer do
+      use ExMCP.Server.Handler
+      use ExMCP.Server.DSL, name: "echo", version: "1"
+      tool "echo", "Echo Unicode" do
+        param :text, :string, required: true
+        run fn args, state ->
+          # Echo alone can hide paired input/output transcoding errors.
+          if args.text != "café 日本語 🪁", do: raise("input was transcoded")
+          {:ok, "café 日本語 🪁", state}
+        end
+      end
+    end
+    {:ok, pid} = EchoServer.start_link(transport: :stdio)
+    ref = Process.monitor(pid)
+    receive do
+      {:DOWN, ^ref, :process, ^pid, :normal} -> :ok
+      {:DOWN, ^ref, :process, ^pid, reason} -> raise inspect(reason)
+    after
+      10_000 -> raise "EOF did not close transport"
+    end
+    """)
+
+    value = "café 日本語 🪁"
+
+    requests = [
+      %{
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: %{
+          protocolVersion: "2025-03-26",
+          capabilities: %{},
+          clientInfo: %{name: "test", version: "1"}
+        }
+      },
+      %{
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: %{name: "echo", arguments: %{text: value}}
+      }
+    ]
+
+    File.write!(input, Enum.map(requests, &[Jason.encode!(&1), "\n"]))
+    paths = :code.get_path() |> Enum.flat_map(&["-pa", to_string(&1)])
+
+    {output, code} =
+      System.cmd(
+        "sh",
+        [
+          "-c",
+          "exec \"$@\" < \"$STDIO_TEST_INPUT\"",
+          "stdio-test",
+          System.find_executable("elixir")
+        ] ++ paths ++ [script],
+        env: [{"LANG", "C"}, {"LC_ALL", "C"}, {"MIX_ENV", "test"}, {"STDIO_TEST_INPUT", input}]
+      )
+
+    assert code == 0
+    responses = output |> String.split("\n", trim: true) |> Enum.map(&Jason.decode!/1)
+    assert length(responses) == 2
+    assert %{"id" => 2, "result" => %{"content" => [%{"text" => ^value}]}} = List.last(responses)
+  end
+end


### PR DESCRIPTION
### The problem

`ExMCP.Server.StdioServer` writes frames with `IO.puts/2`. When the process's group leader is in latin1 mode — which is what an OTP release gets when `LANG`/`LC_ALL` are unset, as under launchd, systemd, or an MCP host that passes a minimal environment — writing a frame containing non-ASCII text exits with:

```
{:no_translation, :unicode, :latin1}
```

The server dies mid-session. Any tool result carrying non-ASCII text triggers it: a post containing an emoji, a display name in Japanese, an accented handle.

### The fix

Pin the device to byte mode and write raw UTF-8 frames, so the encoding of the surrounding environment cannot corrupt or reject protocol output.

### Test

Adds `test/ex_mcp/server/stdio_server_unicode_test.exs`, which drives the server with a latin1 IO device and asserts the frame arrives as UTF-8 bytes. It fails on `master` before the change and passes after; `mix test test/ex_mcp/server/stdio_server_unicode_test.exs` is green on this branch.

### Context

Found while running an MCP server built on ExMCP as a launchd service, where the host environment has no locale set. I have several other fixes on a fork against the stdio and HTTP server paths; if this shape of contribution is useful I'm glad to send them individually.